### PR TITLE
fix: typeError on project creation when no SW360 ID given

### DIFF
--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -128,7 +128,7 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             rid = CycloneDxSupport.get_property_value(cx_comp, CycloneDxSupport.CDX_PROP_SW360ID)
             if not rid:
                 print_red(
-                    + "No SW360 id given for " + cx_comp.name
+                    "No SW360 id given for " + cx_comp.name
                     + ", " + cx_comp.version)
                 continue
 


### PR DESCRIPTION
The change fixes the type error reported in #20. Tested on python 3.10.4.