### PR TITLE
fix: external reference to Siemens standard bom

### DIFF
--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -451,7 +451,7 @@ class SbomCreator():
 
         extref = ExternalReference(
             reference_type=ExternalReferenceType.WEBSITE,
-            url=XsUri("https://code.siemens.com/scpautomation/standard-bom"))
+            url=XsUri("https://code.siemens.com/sbom/standard-bom"))
         tool.external_references.add(extref)
 
         return tool


### PR DESCRIPTION
During usage noticed an inconsistency in the external reference URL of the Siemens standard bom.