### PR TITLE
`project createbom` improvements: add SW360 project metadata and fix components' purls and source/binary urls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
 ## NEXT
 
 * Be more resilient about missing metadata in CycloneDX SBOMs.
-* `project createbom` uses purl from SW360 if available instead of building it
+* `project createbom` uses source url and purl from SW360 if available
 * `project createbom` adds SW360 project name, version and description to SBOM.
 
 ## 2.0.0 (2023-06-02)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 ## NEXT
 
 * Be more resilient about missing metadata in CycloneDX SBOMs.
+* `project createbom` uses purl from SW360 if available instead of building it
 
 ## 2.0.0 (2023-06-02)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 
 * Be more resilient about missing metadata in CycloneDX SBOMs.
 * `project createbom` uses purl from SW360 if available instead of building it
+* `project createbom` adds SW360 project name, version and description to SBOM.
 
 ## 2.0.0 (2023-06-02)
 

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -516,8 +516,18 @@ class SbomCreator():
         if "addtools" in kwargs and kwargs["addtools"]:
             SbomCreator.add_tools(sbom.metadata.tools)
 
+        if "name" in kwargs or "version" in kwargs or "description" in kwargs:
+            sbom.metadata.component = Component(
+                name=kwargs.get("name"),
+                version=kwargs.get("version"),
+                description=kwargs.get("description")
+            )
+
         if bom:
             sbom.components = bom
+            if kwargs.get("addprojectdependencies") and sbom.metadata.component:
+                for component in sbom.components:
+                    sbom.metadata.component.dependencies.add(component.bom_ref)
 
         return sbom
 

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -84,8 +84,8 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                 rel_item["ReleaseMainlineState"] = release_details.get("mainlineState", "")
 
                 rel_item["Language"] = self.list_to_string(release_details.get("languages", ""))
-                rel_item["SourceCodeDownloadUrl"] = release_details.get("sourceCodeDownloadurl", "")
-                rel_item["BinaryDownloadUrl"] = release_details.get("binaryDownloadurl", "")
+                rel_item["SourceFileUrl"] = release_details.get("sourceCodeDownloadurl", "")
+                rel_item["BinaryFileUrl"] = release_details.get("binaryDownloadurl", "")
 
                 rel_item["RepositoryId"] = self.get_external_id("package-url", release_details)
                 if not rel_item["RepositoryId"]:

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -93,10 +93,13 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                 rel_item["Language"] = self.list_to_string(release_details.get("languages", ""))
                 rel_item["SourceCodeDownloadUrl"] = release_details.get("sourceCodeDownloadurl", "")
                 rel_item["BinaryDownloadUrl"] = release_details.get("binaryDownloadurl", "")
-                rel_item["Purl"] = self.get_external_id("purl", release_details)
-                if not rel_item["Purl"]:
+
+                rel_item["RepositoryId"] = self.get_external_id("package-url", release_details)
+                if not rel_item["RepositoryId"]:
                     # try another id name
-                    rel_item["Purl"] = self.get_external_id("package-url", release_details)
+                    rel_item["RepositoryId"] = self.get_external_id("purl", release_details)
+                if rel_item["RepositoryId"]:
+                    rel_item["RepositoryType"] = "package-url"
 
                 if "repository" in release_details:
                     rel_item["Repository"] = release_details["repository"].get("url", "")

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -121,6 +121,16 @@ class CreateBom(capycli.common.script_base.ScriptBase):
 
         return bom
 
+    def create_project_cdx_bom(self, project_id) -> list:
+        bom = self.create_project_bom(project_id)
+
+        cdx_components = []
+        for item in bom:
+            cx_comp = LegacySupport.legacy_component_to_cdx(item)
+            cdx_components.append(cx_comp)
+
+        return cdx_components
+
     def show_command_help(self):
         print("\nusage: CaPyCli project createbom [options]")
         print("Options:")
@@ -178,13 +188,7 @@ class CreateBom(capycli.common.script_base.ScriptBase):
             sys.exit(ResultCode.RESULT_COMMAND_ERROR)
 
         if pid:
-            bom = self.create_project_bom(pid)
-
-            cdx_components = []
-            for item in bom:
-                cx_comp = LegacySupport.legacy_component_to_cdx(item)
-                cdx_components.append(cx_comp)
-
-            CaPyCliBom.write_simple_sbom(cdx_components, args.outputfile)
+            bom = self.create_project_cdx_bom(pid)
+            CaPyCliBom.write_simple_sbom(bom, args.outputfile)
         else:
             print_yellow("  No matching project found")

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -134,7 +134,9 @@ class CreateBom(capycli.common.script_base.ScriptBase):
             cdx_components.append(cx_comp)
 
         creator = SbomCreator()
-        sbom = creator.create(cdx_components, addlicense=True, addprofile=True, addtools=True)
+        sbom = creator.create(cdx_components, addlicense=True, addprofile=True, addtools=True,
+                              name=project.get("name"), version=project.get("version"),
+                              description=project.get("description"), addprojectdependencies=True)
 
         return sbom
 

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -167,7 +167,11 @@ class TestCreateBom(TestBase):
         )
 
         cdx_bom = sut.create_project_cdx_bom("p001")
-        self.assertEqual(cdx_bom[0].purl, release["externalIds"]["package-url"])
+
+        self.assertEqual(cdx_bom.components[0].purl, release["externalIds"]["package-url"])
+        self.assertEqual(cdx_bom.metadata.component.name, project["name"])
+        self.assertEqual(cdx_bom.metadata.component.version, project["version"])
+        self.assertEqual(cdx_bom.metadata.component.description, project["description"])
 
     @responses.activate
     def test_project_show_by_name(self):

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -13,6 +13,7 @@ import responses
 from capycli.common.capycli_bom_support import CaPyCliBom
 from capycli.main.result_codes import ResultCode
 from capycli.project.create_bom import CreateBom
+from cyclonedx.model import ExternalReferenceType
 from tests.test_base import AppArguments, TestBase
 
 
@@ -167,8 +168,11 @@ class TestCreateBom(TestBase):
         )
 
         cdx_bom = sut.create_project_cdx_bom("p001")
-
-        self.assertEqual(cdx_bom.components[0].purl, release["externalIds"]["package-url"])
+        cx_comp = cdx_bom.components[0]
+        self.assertEqual(cx_comp.purl, release["externalIds"]["package-url"])
+        self.assertEqual(cx_comp.external_references[0].url, release["sourceCodeDownloadurl"])
+        self.assertEqual(cx_comp.external_references[0].type, ExternalReferenceType.DISTRIBUTION)
+        self.assertEqual(cx_comp.external_references[0].comment, CaPyCliBom.SOURCE_URL_COMMENT)
         self.assertEqual(cdx_bom.metadata.component.name, project["name"])
         self.assertEqual(cdx_bom.metadata.component.version, project["version"])
         self.assertEqual(cdx_bom.metadata.component.description, project["description"])


### PR DESCRIPTION
This PR fixes "project CreateBom" to store the following data to written BOM:

- feat: SW360 project name, version and description are now added to metadata/component
- fix: purls from linked releases are taken over from SW360, due to a bug capycli always re-created them guessing from name, version and language
- fix: source and binary urls are taken over from SW360, due to a bug they got lost