### PR TITLE
feat: broaden the scope of the find sources command

### DIFF
--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -379,6 +379,15 @@ class CycloneDxSupport():
         return ""
 
     @staticmethod
+    def get_ext_ref_source_code_url(comp: Component) -> Any:
+        for ext_ref in comp.external_references:
+            if (ext_ref.type == ExternalReferenceType.DISTRIBUTION) \
+                    and (ext_ref.comment is None):
+                return ext_ref.url
+
+        return ""
+
+    @staticmethod
     def get_ext_ref_source_url(comp: Component) -> Any:
         for ext_ref in comp.external_references:
             if (ext_ref.type == ExternalReferenceType.DISTRIBUTION) \

--- a/tests/fixtures/sbom_for_find_sources.json
+++ b/tests/fixtures/sbom_for_find_sources.json
@@ -57,12 +57,12 @@
     ]
   },
   "components": [
-	{
+	  {
       "type": "library",
       "bom-ref": "pkg:pypi/colorama@0.4.6",
       "name": "colorama",
       "version": "0.4.6",
-	  "description": "console coloring for Python",
+      "description": "console coloring for Python",
       "licenses": [
         {
           "license": {
@@ -181,7 +181,7 @@
             }
           ]
         },
-		{
+		    {
           "url": "https://github.com/hukkin/tomli/archive/refs/tags/2.0.1.zip",
           "type": "distribution",
           "comment": "source archive (download location)",
@@ -204,18 +204,18 @@
         }
       ]
     },
-	{
-	  "type": "library",
-      "bom-ref": "pkg:pypi/something@0.38.4",
-	  "name": "something",
-      "version": "0.38.4",
-	  "externalReferences": [
-	    {
-          "url": "https://github.com/pypa/something",
-          "type": "vcs"
-        }
-	  ]
-	},
+    {
+      "type": "library",
+        "bom-ref": "pkg:pypi/something@0.38.4",
+      "name": "something",
+        "version": "0.38.4",
+      "externalReferences": [
+        {
+            "url": "https://github.com/pypa/something",
+            "type": "vcs"
+          }
+      ]
+    },
     {
       "type": "library",
       "bom-ref": "pkg:pypi/wheel@0.38.4",
@@ -254,6 +254,72 @@
         {
           "name": "siemens:sw360Id",
           "value": "e0995819173d4ac8b1a4da3548935976"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/into-stream@6.0.0?package-id=e7c649f25e04c19c",
+      "author": "Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)",
+      "name": "into-stream",
+      "version": "6.0.0",
+      "description": "Convert a string/promise/array/iterable/asynciterable/buffer/typedarray/arraybuffer/object into a stream",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/into-stream@6.0.0",
+      "externalReferences": [
+        {
+          "url": "sindresorhus/into-stream",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/tiny-lru@11.0.1?package-id=13dfb654ee72d03b",
+      "author": "Jason Mulligan <jason.mulligan@avoidwork.com>",
+      "name": "tiny-lru",
+      "version": "11.0.1",
+      "description": "Tiny LRU cache for Client or Server",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tiny-lru@11.0.1",
+      "externalReferences": [
+        {
+          "url": "git://github.com/avoidwork/tiny-lru.git",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/yamljs@0.3.0?package-id=b6b9b0e6c15f445a",
+      "author": "Jeremy Faivre <contact@jeremyfa.com>",
+      "name": "yamljs",
+      "version": "0.3.0",
+      "description": "Standalone JavaScript YAML 1.2 Parser & Encoder. Works under node.js and all major browsers. Also brings command line YAML/JSON conversion tools.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/yamljs@0.3.0",
+      "externalReferences": [
+        {
+          "url": "git+http://github.com/jeremyfa/yaml.js.git",
+          "type": "distribution"
         }
       ]
     }

--- a/tests/test_find_sources.py
+++ b/tests/test_find_sources.py
@@ -98,34 +98,54 @@ class TestFindSources(TestBase):
         self.assertTrue(self.INPUTFILE in out)
         self.assertTrue(self.OUTPUTFILE in out)
         self.assertTrue("Using anonymous GitHub access" in out)
-        self.assertTrue("5 components read from SBOM" in out)
+        self.assertTrue("8 components read from SBOM" in out)
+        self.assertTrue("1 source files were already available" in out)
+        self.assertTrue("5 source file URLs were found" in out)
 
         sbom = CaPyCliBom.read_sbom(args.outputfile)
         self.assertIsNotNone(sbom)
-        self.assertEqual(5, len(sbom.components))
+        self.assertEqual(8, len(sbom.components))
         self.assertEqual("colorama", sbom.components[0].name)
         self.assertEqual("0.4.6", sbom.components[0].version)
         self.assertEqual(
             "https://github.com/tartley/colorama/archive/refs/tags/0.4.6.zip",
             CycloneDxSupport.get_ext_ref_source_url(sbom.components[0]))
 
-        self.assertEqual("python", sbom.components[1].name)
-        self.assertEqual("3.8", sbom.components[1].version)
+        self.assertEqual("into-stream", sbom.components[1].name)
+        self.assertEqual("6.0.0", sbom.components[1].version)
+        self.assertEqual(
+            "https://github.com/sindresorhus/into-stream/archive/refs/tags/v6.0.0.zip",
+            CycloneDxSupport.get_ext_ref_source_url(sbom.components[1]))
 
-        self.assertEqual("something", sbom.components[2].name)
-        self.assertEqual("0.38.4", sbom.components[2].version)
+        self.assertEqual("python", sbom.components[2].name)
+        self.assertEqual("3.8", sbom.components[2].version)
 
-        self.assertEqual("tomli", sbom.components[3].name)
-        self.assertEqual("2.0.1", sbom.components[3].version)
+        self.assertEqual("something", sbom.components[3].name)
+        self.assertEqual("0.38.4", sbom.components[3].version)
+
+        self.assertEqual("tiny-lru", sbom.components[4].name)
+        self.assertEqual("11.0.1", sbom.components[4].version)
+        self.assertEqual(
+            "https://github.com/avoidwork/tiny-lru/archive/refs/tags/11.0.1.zip",
+            CycloneDxSupport.get_ext_ref_source_url(sbom.components[4]))
+
+        self.assertEqual("tomli", sbom.components[5].name)
+        self.assertEqual("2.0.1", sbom.components[5].version)
         self.assertEqual(
             "https://github.com/hukkin/tomli/archive/refs/tags/2.0.1.zip",
-            CycloneDxSupport.get_ext_ref_source_url(sbom.components[3]))
+            CycloneDxSupport.get_ext_ref_source_url(sbom.components[5]))
 
-        self.assertEqual("wheel", sbom.components[4].name)
-        self.assertEqual("0.38.4", sbom.components[4].version)
+        self.assertEqual("wheel", sbom.components[6].name)
+        self.assertEqual("0.38.4", sbom.components[6].version)
         self.assertEqual(
             "https://github.com/pypa/wheel/archive/refs/tags/0.38.4.zip",
-            CycloneDxSupport.get_ext_ref_source_url(sbom.components[4]))
+            CycloneDxSupport.get_ext_ref_source_url(sbom.components[6]))
+
+        self.assertEqual("yamljs", sbom.components[7].name)
+        self.assertEqual("0.3.0", sbom.components[7].version)
+        self.assertEqual(
+            "https://github.com/jeremyfa/yaml.js/archive/refs/tags/v0.3.0.zip",
+            CycloneDxSupport.get_ext_ref_source_url(sbom.components[7]))
 
         self.delete_file(args.outputfile)
 
@@ -144,6 +164,18 @@ class TestFindSources(TestBase):
 
         # trailing #readme
         repo = "https://github.com/restsharp/RestSharp#readme"
+        actual = capycli.bom.findsources.FindSources.get_repo_name(repo)
+
+        self.assertEqual("restsharp/RestSharp", actual)
+
+        # prefix git
+        repo = "git://github.com/restsharp/RestSharp#readme"
+        actual = capycli.bom.findsources.FindSources.get_repo_name(repo)
+
+        self.assertEqual("restsharp/RestSharp", actual)
+
+        # prefix git+https
+        repo = "git+https://github.com/restsharp/RestSharp#readme"
         actual = capycli.bom.findsources.FindSources.get_repo_name(repo)
 
         self.assertEqual("restsharp/RestSharp", actual)


### PR DESCRIPTION
Command "bom findsources" is extended to cover external references of type "distribution" and accepts a broader format variety of GitHub URLs (e.g., starting with git+https://, or git://, or missing URL altogether but having a valid GitHub project name format).

Closes #23