### PR TITLE
fix(project CreateBom): include SW360 source attachments and repository url

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 * The `-o` parameter of the command `project GetLicenseInfo` is now optional.
   But you still need this output when you want to create a Readme.
 * `project createbom` uses source url and purl from SW360 if available
+* `project createbom` adds first SW360 source attachment of each releases as external reference to SBOM.
 * `project createbom` adds SW360 project name, version and description to SBOM.
 
 ## 2.0.0 (2023-06-02)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@
 * Be more resilient about missing metadata in CycloneDX SBOMs.
 * The `-o` parameter of the command `project GetLicenseInfo` is now optional.
   But you still need this output when you want to create a Readme.
-* `project createbom` uses source url and purl from SW360 if available
+* `project createbom` add purl, source and repository url from SW360 if available
 * `project createbom` adds first SW360 source attachment of each releases as external reference to SBOM.
 * `project createbom` adds SW360 project name, version and description to SBOM.
 

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -95,7 +95,7 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                     rel_item["RepositoryType"] = "package-url"
 
                 if "repository" in release_details:
-                    rel_item["Repository"] = release_details["repository"].get("url", "")
+                    rel_item["RepositoryUrl"] = release_details["repository"].get("url", "")
 
                 source_attachment = self.get_attachment("SOURCE", release_details)
                 if source_attachment:

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -99,13 +99,13 @@ class CreateBom(capycli.common.script_base.ScriptBase):
 
                 source_attachment = self.get_attachment("SOURCE", release_details)
                 if source_attachment:
-                    rel_item["SourceCodeFile"] = source_attachment.get("filename", "")
-                    rel_item["SourceCodeFileSha1"] = source_attachment.get("sha1", "")
+                    rel_item["SourceFile"] = source_attachment.get("filename", "")
+                    rel_item["SourceFileHash"] = source_attachment.get("sha1", "")
 
                 binary_attachment = self.get_attachment("BINARY", release_details)
                 if binary_attachment:
                     rel_item["BinaryFile"] = binary_attachment.get("filename", "")
-                    rel_item["BinarySha1"] = binary_attachment.get("sha1", "")
+                    rel_item["BinaryFileHash"] = binary_attachment.get("sha1", "")
 
             except sw360.SW360Error as swex:
                 print_red("    ERROR: unable to access project:" + repr(swex))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -365,6 +365,10 @@ class TestBase(unittest.TestCase):
                 "package-url": "pkg:pypi/cli-support@1.3"
             },
             "createdOn": "2023-03-14",
+            "repository": {
+                "url": "https://github.com/sw360/clipython.git",
+                "repositorytype": "GIT"
+            },
             "mainlineState": "SPECIFIC",
             "clearingState": "APPROVED",
             "createdBy": "thomas.graf@siemens.com",

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -170,9 +170,19 @@ class TestCreateBom(TestBase):
         cdx_bom = sut.create_project_cdx_bom("p001")
         cx_comp = cdx_bom.components[0]
         self.assertEqual(cx_comp.purl, release["externalIds"]["package-url"])
-        self.assertEqual(cx_comp.external_references[0].url, release["sourceCodeDownloadurl"])
-        self.assertEqual(cx_comp.external_references[0].type, ExternalReferenceType.DISTRIBUTION)
-        self.assertEqual(cx_comp.external_references[0].comment, CaPyCliBom.SOURCE_URL_COMMENT)
+
+        ext_refs_src_url = [e for e in cx_comp.external_references if e.comment == CaPyCliBom.SOURCE_URL_COMMENT]
+        self.assertEqual(len(ext_refs_src_url), 1)
+        self.assertEqual(ext_refs_src_url[0].url, release["sourceCodeDownloadurl"])
+        self.assertEqual(ext_refs_src_url[0].type, ExternalReferenceType.DISTRIBUTION)
+
+        ext_refs_src_file = [e for e in cx_comp.external_references if e.comment == CaPyCliBom.SOURCE_FILE_COMMENT]
+        self.assertEqual(len(ext_refs_src_file), 1)
+        self.assertEqual(ext_refs_src_file[0].url, release["_embedded"]["sw360:attachments"][0]["filename"])
+        self.assertEqual(ext_refs_src_file[0].type, ExternalReferenceType.DISTRIBUTION)
+        self.assertEqual(ext_refs_src_file[0].hashes[0].alg, "SHA-1")
+        self.assertEqual(ext_refs_src_file[0].hashes[0].content, release["_embedded"]["sw360:attachments"][0]["sha1"])
+
         self.assertEqual(cdx_bom.metadata.component.name, project["name"])
         self.assertEqual(cdx_bom.metadata.component.version, project["version"])
         self.assertEqual(cdx_bom.metadata.component.description, project["description"])

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -183,6 +183,10 @@ class TestCreateBom(TestBase):
         self.assertEqual(ext_refs_src_file[0].hashes[0].alg, "SHA-1")
         self.assertEqual(ext_refs_src_file[0].hashes[0].content, release["_embedded"]["sw360:attachments"][0]["sha1"])
 
+        ext_refs_vcs = [e for e in cx_comp.external_references if e.type == ExternalReferenceType.VCS]
+        self.assertEqual(len(ext_refs_vcs), 1)
+        self.assertEqual(ext_refs_vcs[0].url, release["repository"]["url"])
+
         self.assertEqual(cdx_bom.metadata.component.name, project["name"])
         self.assertEqual(cdx_bom.metadata.component.version, project["version"])
         self.assertEqual(cdx_bom.metadata.component.description, project["description"])


### PR DESCRIPTION
These got lost because they were added internally using a wrong legacy attribute.

This will be changed again when refactoring createbom as suggested in #30, but I thought it might be worth having a working version  first as reference.

