### PR TITLE
Issue39 first pytest file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,8 @@
 * Be more resilient about missing metadata in CycloneDX SBOMs.
 * The `-o` parameter of the command `project GetLicenseInfo` is now optional.
   But you still need this output when you want to create a Readme.
-* `project createbom` add purl, source and repository url from SW360 if available
+* `project createbom` add purls, source and repository url from SW360 if available.
+  If multiple purls are found, a warning is printed asking user to manually edit SBOM.
 * `project createbom` add SW360 source and binary attachments as external reference to SBOM.
 * `project createbom` adds SW360 project name, version and description to SBOM.
 
@@ -27,7 +28,7 @@
   * `bom map` will report matches by name, but different version **only** if `-all` has been specified.
     The original idea of CaPyCLI was to report as many potential matches as possible and to let the user
     decide which match to take by editing the SBOM. But it seems that many users did not read the documentation
-    and the expectations were different. Therefore the default behavior has been changed.  
+    and the expectations were different. Therefore the default behavior has been changed.
     The original behavior of versions prior to 2.x can be enabled via the `-all` switch.
 
 ## 2.0.0.dev (2023-05-19)

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -17,6 +17,7 @@ from cyclonedx.model.component import Component
 import capycli.common.script_base
 from capycli import get_logger
 from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport, SbomCreator
+from capycli.common.purl_utils import PurlUtils
 from capycli.common.print import print_red, print_text, print_yellow
 from capycli.main.result_codes import ResultCode
 
@@ -58,6 +59,12 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                 if not purl:
                     # try another id name
                     purl = self.get_external_id("purl", release_details)
+
+                purl = PurlUtils.parse_purls_from_external_id(purl)
+                if len(purl) > 1:
+                    print_yellow("      Multiple purls added for", release["name"], release["version"])
+                    print_yellow("      You must remove all but one in your SBOM!")
+                purl = " ".join(purl)
 
                 if purl:
                     rel_item = Component(name=release["name"], version=release["version"], purl=purl, bom_ref=purl)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -63,7 +63,7 @@ class AppArguments():
         self.outputformat = ""
 
 
-class TestBase(unittest.TestCase):
+class TestBasePytest:
     MYTOKEN = "MYTOKEN"
     MYURL = "https://my.server.com/"
     ERROR_MSG_NO_LOGIN = "Unable to login"
@@ -474,3 +474,7 @@ class TestBase(unittest.TestCase):
   <ExternalIds />
 </ComponentLicenseInformation>
             """
+
+
+class TestBase(unittest.TestCase, TestBasePytest):
+    pass


### PR DESCRIPTION
Note that his is a PR on top of #37, so it includes the change from #37.

Fixes #39 by adding the necessary infrastructure for pytest-based test classes and refactoring the "project createbom" testcases to use it.

This shows the pytest assert syntax and how to capture stdout with pytest using the "capsys" fixture.