### PR TITLE
fix(options): "project CreateBom" missing in cmd summary

### DIFF
--- a/capycli/main/options.py
+++ b/capycli/main/options.py
@@ -66,6 +66,7 @@ class CommandlineSupport():
         Create            create or update a project on SW360
         Update            update an exiting project, preserving linked releases
         GetLicenseInfo    get license info of all project components
+        CreateBom         create a SBOM for a project on SW360
         CreateReadme      create a Readme_OSS
         Vulnerabilities   show security vulnerabilities of a project
         ECC               show export control status of a project


### PR DESCRIPTION
The command was listed in "capycli project --help", but not in "capycli --help"