### PR TITLE
fix: legacy to capycli BOM convert fix for sourceUrl

### DIFF
--- a/capycli/bom/legacy.py
+++ b/capycli/bom/legacy.py
@@ -147,7 +147,7 @@ class LegacySupport():
         if sourceFileUrl:
             ext_ref = ExternalReference(
                 reference_type=ExternalReferenceType.DISTRIBUTION,
-                comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                comment=CaPyCliBom.SOURCE_FILE_COMMENT,
                 url=XsUri(sourceFileUrl))
             hash = item.get("SourceFileHash", "")
             if hash:
@@ -160,7 +160,7 @@ class LegacySupport():
             if sourceUrl:
                 ext_ref = ExternalReference(
                     reference_type=ExternalReferenceType.DISTRIBUTION,
-                    comment=CaPyCliBom.SOURCE_FILE_COMMENT,
+                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
                     url=XsUri(sourceUrl))
                 hash = item.get("SourceFileHash", "")
                 if hash:


### PR DESCRIPTION
When we convert BOM from legacy to capycli [ capycli bom convert  -i <input.json> -if legacy -o <output.json> -of capycli ] "SourceUrl" from legacy BOM is getting converted to "source archive (local copy)" in capycli BOM.

What should be the actual conversion?
It should be converted to "source archive (download location)"