### PR TITLE
Finally fix #70 with correct percent-encoding

### DIFF
--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -12,6 +12,7 @@ import os
 import pathlib
 import re
 import sys
+import urllib
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -682,6 +683,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
 
         value_match = match.get("SourceFile", "")
         if value_match:
+            value_match = urllib.parse.quote(value_match)
             ext_ref_src_file = CycloneDxSupport.get_ext_ref(
                 component,
                 ExternalReferenceType.DISTRIBUTION,
@@ -697,6 +699,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
 
         value_match = match.get("BinaryFile", "")
         if value_match:
+            value_match = urllib.parse.quote(value_match)
             ext_ref_bin_file = CycloneDxSupport.get_ext_ref(
                 component,
                 ExternalReferenceType.DISTRIBUTION,

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -10,7 +10,6 @@ import json
 import os
 import pathlib
 import uuid
-import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -356,14 +355,9 @@ class CycloneDxSupport():
     @staticmethod
     def set_ext_ref(comp: Component, type: ExternalReferenceType, comment: str, value: str,
                     hash_algo: str = "", hash: str = "") -> None:
-
-        if re.search(XsUri._INVALID_URI_REGEX, str(value)):
-          cleaned_uri = re.sub(XsUri._INVALID_URI_REGEX, ':', str(value))
-        else:
-            cleaned_uri = str(value)
         ext_ref = ExternalReference(
             reference_type=type,
-            url=XsUri(cleaned_uri),
+            url=XsUri(value),
             comment=comment)
 
         if hash_algo and hash:

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -2491,8 +2491,8 @@ class CapycliTestBomMap(CapycliTestBase):
         match["Language"] = "C#"
         match["ComponentId"] = "123"
         match["SourceUrl"] = "http://123"
-        match["SourceFile"] = "123.zip"
-        match["BinaryFile"] = "123.dll"
+        match["SourceFile"] = "123%1.zip"
+        match["BinaryFile"] = "123%.dll"
         match["ProjectSite"] = "http://somewhere"
         match["Sw360Id"] = "007"
         match["ComponentId"] = "0815"
@@ -2501,8 +2501,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertEqual("2", updated.version)
         self.assertEqual("C#", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_LANGUAGE))
         self.assertEqual("http://123", str(CycloneDxSupport.get_ext_ref_source_url(updated)))
-        self.assertEqual("123.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
-        self.assertEqual("123.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
+        self.assertEqual("123%251.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
+        self.assertEqual("123%25.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
         self.assertEqual("http://somewhere", str(CycloneDxSupport.get_ext_ref_website(updated)))
         self.assertEqual("007", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_SW360ID))
 
@@ -2548,8 +2548,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertEqual("2", updated.version)
         self.assertEqual("C#", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_LANGUAGE))
         self.assertEqual("http://123", str(CycloneDxSupport.get_ext_ref_source_url(updated)))
-        self.assertEqual("123.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
-        self.assertEqual("123.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
+        self.assertEqual("123%251.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
+        self.assertEqual("123%25.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
         self.assertEqual("http://somewhere", str(CycloneDxSupport.get_ext_ref_website(updated)))
         self.assertEqual("007", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_SW360ID))
         self.assertEqual("0815", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_COMPONENT_ID))


### PR DESCRIPTION
As discussed in #71, the previous fix hard-replaced certain special characters by ":" in all external references, so this reverts #71.

Instead, I think we need to percent-encode filenames.