### PR TITLE
fix: urls coming from granularity file are repository urls and not source code download urls

### DIFF
--- a/capycli/bom/check_granularity.py
+++ b/capycli/bom/check_granularity.py
@@ -156,8 +156,8 @@ class CheckGranularity(capycli.common.script_base.ScriptBase):
         if source_url_bak:
             CycloneDxSupport.update_or_set_ext_ref(
                 component_new,
-                ExternalReferenceType.DISTRIBUTION,
-                CaPyCliBom.SOURCE_URL_COMMENT,
+                ExternalReferenceType.VCS,
+                None,
                 source_url_bak
             )
 

--- a/tests/test_check_granularity.py
+++ b/tests/test_check_granularity.py
@@ -134,7 +134,7 @@ class TestCheckGranularity(TestBase):
         self.assertEqual("Angular", sbom.components[0].name)
         self.assertEqual("15.2.6", sbom.components[0].version)
         val = CycloneDxSupport.get_ext_ref_source_url(sbom.components[0])
-        self.assertEqual("https://github.com/angular/angular", str(val))
+        self.assertEqual("", str(val))
 
         self.assertEqual("certifi", sbom.components[1].name)
         self.assertEqual("2022.12.7", sbom.components[1].version)


### PR DESCRIPTION
Urls coming from granularity file are repository urls and not source code download urls. Hence making changes in check_granularity.py file and related testcase.