### PR TITLE
fix: initialise local variable 'ext_ref' early

### DIFF
--- a/capycli/dependencies/javascript.py
+++ b/capycli/dependencies/javascript.py
@@ -200,6 +200,7 @@ class GetJavascriptDependencies(capycli.common.dependencies_base.DependenciesBas
         Find metadata for a single component.
         """
         version = ""
+        ext_ref = ""
         if bomitem.version:
             version = bomitem.version
         info = self.find_package_info(


### PR DESCRIPTION
This is a fix for https://github.com/sw360/capycli/issues/75

Initialise the local variable 'ext_ref' to get rid of the bug