### PR TITLE
fix: bom_ref is not set always hence adding purl also for the checks

### DIFF
--- a/capycli/bom/findsources.py
+++ b/capycli/bom/findsources.py
@@ -489,7 +489,7 @@ class FindSources(capycli.common.script_base.ScriptBase):
             source_url = None
 
             # skip source URL check for debian components as github url s are invalid for Debian.
-            if component.bom_ref.value.startswith("pkg:deb/debian/"):
+            if str(component.purl).startswith("pkg:deb/debian/") or str(component.bom_ref).startswith("pkg:deb/debian"):
                 print_red("No source code check for debian components!")
                 continue
 


### PR DESCRIPTION
As we skip source url checks for debian components, the if condition is updated to add checks for bom_ref and purl