### PR TITLE
Use XsUri when updating an existing external reference

### DIFF
--- a/capycli/bom/filter_bom.py
+++ b/capycli/bom/filter_bom.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from cyclonedx.model import ExternalReferenceType
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
+from packageurl import PackageURL
 
 import capycli.common.json_support
 import capycli.common.script_base
@@ -139,7 +140,7 @@ class FilterBom(capycli.common.script_base.ScriptBase):
         if "RepositoryType" in filterentry:
             rtype = filterentry.get("RepositoryType", "")
         if rtype and ("RepositoryId" in filterentry) and filterentry.get("RepositoryId", ""):
-            component.purl = filterentry.get("RepositoryId", "")
+            component.purl = PackageURL.from_string(filterentry.get("RepositoryId", ""))
 
         if ("Sw360Id" in filterentry) and filterentry.get("Sw360Id", ""):
             CycloneDxSupport.update_or_set_property(

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -376,7 +376,7 @@ class CycloneDxSupport():
                 break
 
         if ext_ref:
-            ext_ref.url = value
+            ext_ref.url = XsUri(value)
         else:
             CycloneDxSupport.set_ext_ref(comp, type, comment, value)
 

--- a/tests/test_bom_filter.py
+++ b/tests/test_bom_filter.py
@@ -359,11 +359,9 @@ class TestBomFilter(TestBase):
         sut = capycli.bom.filter_bom.FilterBom()
 
         inputfile = os.path.join(os.path.dirname(__file__), "fixtures", self.INPUTFILE1)
-        outputfile = os.path.join(os.path.dirname(__file__), "fixtures", self.OUTPUTFILE)
         filterfile = os.path.join(os.path.dirname(__file__), "fixtures", self.FILTERFILE)
 
         # clean any existing test files
-        self.delete_file(outputfile)
         self.delete_file(filterfile)
 
         self.assertTrue(os.path.exists(inputfile), "Filter input file not found!")
@@ -390,20 +388,9 @@ class TestBomFilter(TestBase):
 
         capycli.common.json_support.write_json_to_file(filter, filterfile)
 
-        # create argparse command line argument object
-        args = AppArguments()
-        args.command = []
-        args.command.append("bom")
-        args.command.append("filter")
-        args.inputfile = inputfile
-        args.outputfile = outputfile
-        args.filterfile = filterfile
-        args.verbose = True
+        bom = CaPyCliBom.read_sbom(inputfile)
+        bom = sut.filter_bom(bom, filterfile)
 
-        sut.run(args)
-        self.assertTrue(os.path.exists(outputfile), "Filter output file not created!")
-
-        bom = CaPyCliBom.read_sbom(outputfile)
         self.assertEqual(4, len(bom.components))
         self.assertEqual(component["Name"], bom.components[2].name)
         self.assertEqual(component["Version"], bom.components[2].version)
@@ -418,7 +405,6 @@ class TestBomFilter(TestBase):
             CycloneDxSupport.get_property_value(bom.components[2], CycloneDxSupport.CDX_PROP_SW360ID))
 
         # clean test files
-        self.delete_file(outputfile)
         self.delete_file(filterfile)
 
 

--- a/tests/test_bom_filter.py
+++ b/tests/test_bom_filter.py
@@ -14,6 +14,7 @@ import capycli.common.json_support
 import capycli.common.script_base
 from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport
 from capycli.main.result_codes import ResultCode
+from cyclonedx.model import XsUri
 from tests.test_base import AppArguments, TestBase
 
 
@@ -392,6 +393,9 @@ class TestBomFilter(TestBase):
         bom = sut.filter_bom(bom, filterfile)
 
         self.assertEqual(4, len(bom.components))
+        for comp in bom.components:
+            for ext_ref in comp.external_references:
+                self.assertIsInstance(ext_ref.url, XsUri)
         self.assertEqual(component["Name"], bom.components[2].name)
         self.assertEqual(component["Version"], bom.components[2].version)
         self.assertEqual(component["RepositoryId"], bom.components[2].purl.to_string())

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -10,7 +10,7 @@ import os
 from typing import Any, Dict
 
 import responses
-from cyclonedx.model import ExternalReferenceType
+from cyclonedx.model import ExternalReferenceType, XsUri
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
 from packageurl import PackageURL
@@ -2500,6 +2500,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertEqual("b", updated.name)
         self.assertEqual("2", updated.version)
         self.assertEqual("C#", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_LANGUAGE))
+        for ext_ref in updated.external_references:
+            self.assertIsInstance(ext_ref.url, XsUri)
         self.assertEqual("http://123", str(CycloneDxSupport.get_ext_ref_source_url(updated)))
         self.assertEqual("123%251.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
         self.assertEqual("123%25.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
@@ -2524,6 +2526,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertEqual("2", updated.version)
         self.assertEqual("Java", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_LANGUAGE))
         self.assertEqual("http://456", str(CycloneDxSupport.get_ext_ref_source_url(comp)))
+        for ext_ref in updated.external_references:
+            self.assertIsInstance(ext_ref.url, XsUri)
         self.assertEqual("456.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
         self.assertEqual("456.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))
         self.assertEqual("http://somewhereelse", str(CycloneDxSupport.get_ext_ref_website(updated)))
@@ -2547,6 +2551,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertEqual("b", updated.name)
         self.assertEqual("2", updated.version)
         self.assertEqual("C#", CycloneDxSupport.get_property_value(updated, CycloneDxSupport.CDX_PROP_LANGUAGE))
+        for ext_ref in updated.external_references:
+            self.assertIsInstance(ext_ref.url, XsUri)
         self.assertEqual("http://123", str(CycloneDxSupport.get_ext_ref_source_url(updated)))
         self.assertEqual("123%251.zip", str(CycloneDxSupport.get_ext_ref_source_file(updated)))
         self.assertEqual("123%25.dll", str(CycloneDxSupport.get_ext_ref_binary_file(updated)))

--- a/tests/test_get_dependencies_javascript.py
+++ b/tests/test_get_dependencies_javascript.py
@@ -178,7 +178,7 @@ class TestGetDependenciesJavascript(TestBase):
         self.assertEqual(1, len(enhanced.components))
         self.assertEqual("zone.js", enhanced.components[0].name)
         self.assertEqual("Zones for JavaScript", enhanced.components[0].description)
-        val = CycloneDxSupport.get_ext_ref_source_url(sbom.components[0])
+        val = str(CycloneDxSupport.get_ext_ref_source_url(sbom.components[0]))
         self.assertEqual("", val)
 
         self.delete_file("test_package_lock_1.json")
@@ -202,7 +202,7 @@ class TestGetDependenciesJavascript(TestBase):
         self.assertEqual(1, len(enhanced.components))
         self.assertEqual("rxjs", enhanced.components[0].name)
         self.assertEqual("Reactive Extensions for modern JavaScript", enhanced.components[0].description)
-        val = CycloneDxSupport.get_ext_ref_source_url(sbom.components[0])
+        val = str(CycloneDxSupport.get_ext_ref_source_url(sbom.components[0]))
         self.assertEqual("https://github.com/reactivex/rxjs/archive/refs/tags/7.8.0.zip", val)
 
         self.delete_file("test_package_lock_3.json")


### PR DESCRIPTION
Current CaPyCli code set the URL to a string internally which doesn't harm when the SBOM is immediately written to a file. If you however want to manipulate the SBOM internally, it can lead to problems as discussed in #79.

