### PR TITLE
fix(project createBom): store multiple purls in property "purl_list"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 ## NEXT
 
 * make `findsources` more resilient against SW360 issues.
+* `project createbom` now stores multiple purls in the property "purl_list" instead of
+  trying to encode them in a strange way in the "purl" field.
 
 ## 2.5.1 (2024-10-16)
 

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -69,16 +69,15 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                     purl = self.get_external_id("purl", release_details)
 
                 purls = PurlUtils.parse_purls_from_external_id(purl)
-                if len(purls) > 1:
-                    print_yellow("      Multiple purls added for", release["name"], release["version"])
-                    print_yellow("      You must remove all but one in your SBOM!")
-                purl = " ".join(purls).strip()
-
-                if purl:
-                    rel_item = Component(name=release["name"], version=release["version"],
-                                         purl=PackageURL.from_string(purl), bom_ref=purl)
-                else:
+                if len(purls) != 1:
                     rel_item = Component(name=release["name"], version=release["version"])
+                    if len(purls) > 1:
+                        print_yellow("      Multiple purls for", release["name"], release["version"])
+                        print_yellow("      Stored them in property purl_list in your SBOM!")
+                        CycloneDxSupport.set_property(rel_item, "purl_list", " ".join(purls))
+                elif len(purls) == 1:
+                    rel_item = Component(name=release["name"], version=release["version"],
+                                         purl=PackageURL.from_string(purls[0]), bom_ref=purls[0])
 
                 for key, property in (("clearingState", CycloneDxSupport.CDX_PROP_CLEARING_STATE),
                                       ("mainlineState", CycloneDxSupport.CDX_PROP_REL_STATE)):

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -13,7 +13,7 @@ import pytest
 import responses
 from cyclonedx.model import ExternalReferenceType
 
-from capycli.common.capycli_bom_support import CaPyCliBom
+from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport
 from capycli.main.result_codes import ResultCode
 from capycli.project.create_bom import CreateBom
 from tests.test_base import AppArguments, TestBasePytest
@@ -153,10 +153,10 @@ class TestCreateBom(TestBasePytest):
         cdx_components = sut.create_project_bom(self.get_project_for_test())
         captured = capsys.readouterr()
 
-        assert "Multiple purls added" in captured.out
-        assert cdx_components[0].purl is not None
-        if cdx_components[0].purl:
-            assert cdx_components[0].purl.to_string() == "pkg:deb/debian/cli-support%401.3-1%20pkg:pypi/cli-support@1.3"
+        assert "Stored them in property purl_list" in captured.out
+        assert cdx_components[0].purl is None
+        purl_raw = CycloneDxSupport.get_property(cdx_components[0], "purl_list").value
+        assert purl_raw == "pkg:deb/debian/cli-support@1.3-1 pkg:pypi/cli-support@1.3"
 
     @responses.activate
     def test_project_by_id(self) -> None:


### PR DESCRIPTION
My first try to store multiple purls separated by blanks (violating the CycloneDX spec) and asking the user to fix the SBOM probably was a bad idea from the beginning. Due to libary updates, the subsequent PURLs were now encoded as part of the qualifiers which was hard to understand and parse. So better keep the purl empty and store the list in a separate property "purl_list".

Fixes #87