### PR TITLE
fix: override logic of sw360 urls and rework prevention of .git upload

### DIFF
--- a/capycli/bom/create_components.py
+++ b/capycli/bom/create_components.py
@@ -361,10 +361,6 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
             filename = str(CycloneDxSupport.get_ext_ref_source_file(cx_comp))
             filehash = str(CycloneDxSupport.get_source_file_hash(cx_comp))
 
-            if filename is not None and filename.endswith('.git'):
-                print_red("    WARNING: resetting filename to prevent uploading .git file")
-                filename = None
-
         if filetype in ["BINARY", "BINARY_SELF"]:
             url = str(CycloneDxSupport.get_ext_ref_binary_url(cx_comp))
             filename = str(CycloneDxSupport.get_ext_ref_binary_file(cx_comp))
@@ -377,6 +373,10 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
             filename_parsed = urlparse(url)
             if filename_parsed:
                 filename = os.path.basename(filename_parsed.path)
+
+        if filetype in ["SOURCE", "SOURCE_SELF"] and filename is not None and filename.endswith('.git'):
+            print_red("    WARNING: resetting filename to prevent uploading .git file")
+            filename = None
 
         if not filename:
             print_red("    Unable to identify filename from url!")

--- a/capycli/bom/create_components.py
+++ b/capycli/bom/create_components.py
@@ -299,8 +299,6 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
                 print_yellow(
                     "    WARNING: SW360 source URL", release_data["sourceCodeDownloadurl"],
                     "differs from BOM URL", data["sourceCodeDownloadurl"])
-                if data["sourceCodeDownloadurl"].endswith(('zip', 'tgz', 'tar.gz', 'tar')):
-                    update_data["sourceCodeDownloadurl"] = data["sourceCodeDownloadurl"]
 
         if "binaryDownloadurl" in data and data["binaryDownloadurl"]:
             if not release_data.get("binaryDownloadurl", ""):
@@ -363,14 +361,14 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
             filename = str(CycloneDxSupport.get_ext_ref_source_file(cx_comp))
             filehash = str(CycloneDxSupport.get_source_file_hash(cx_comp))
 
+            if filename is not None and filename.endswith('.git'):
+                print_red("    WARNING: resetting filename to prevent uploading .git file")
+                filename = None
+
         if filetype in ["BINARY", "BINARY_SELF"]:
             url = str(CycloneDxSupport.get_ext_ref_binary_url(cx_comp))
             filename = str(CycloneDxSupport.get_ext_ref_binary_file(cx_comp))
             filehash = str(CycloneDxSupport.get_binary_file_hash(cx_comp))
-
-        if filename is not None and filename.endswith('.git'):
-            print_red("    WARNING: resetting filename to prevent uploading .git file")
-            filename = None
 
         # Note that we retrieve the SHA1 has from the CycloneDX data.
         # But there is no guarantee that this *IS* really a SHA1 hash!

--- a/tests/test_bom_create_releases.py
+++ b/tests/test_bom_create_releases.py
@@ -675,9 +675,6 @@ class CapycliTestBomCreate(CapycliTestBase):
         responses.add(
             responses.GET, 'https://github.com/babel/babel.git',
             body="content")
-        responses.add(
-            responses.POST, SW360_BASE_URL + 'releases/06a6e7/attachments',
-            match=[upload_matcher("babel.git")])
 
         self.app.download = True
         item = Component(
@@ -693,7 +690,7 @@ class CapycliTestBomCreate(CapycliTestBase):
 
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
         captured = self.capsys.readouterr()  # type: ignore
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 0
         assert "WARNING: resetting filename to prevent uploading .git file" in captured.out
         assert captured.err == ""
 


### PR DESCRIPTION
This pull request addresses 1st and 2nd point of the https://github.com/sw360/capycli/issues/100 issue.

1. It reverts the override of the source code SW360 URL when the capycli recognises the source code download URL ending with .zip, .tgz, .tar.gz, .tar.
2. Prevention of the .git file upload is now done only for the SOURCE and SOURCE_SELF filetype (with added tests).