### PR TITLE
Draft: FindSources w/o always fetching all tags

### DIFF
--- a/capycli/bom/findsources.py
+++ b/capycli/bom/findsources.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 from typing import Any, Dict, List, Tuple
+from urllib.parse import urlparse, parse_qs
 
 import requests
 import semver
@@ -40,6 +41,7 @@ class FindSources(capycli.common.script_base.ScriptBase):
         self.verbose: bool = False
         self.version_regex = re.compile(r"[\d+\.|_]+[\d+]")
         self.github_project_name_regex = re.compile(r"^[a-zA-Z0-9-]+(/[a-zA-Z0-9-]+)*$")
+        self.github_header_link_regex = re.compile(r'<([^>]*)>\s*;\s*rel\s*=\s*(("[^"]*")|(\'[^\']*\')|([^ ]*))')
         self.github_name: str = ""
         self.github_token: str = ""
         self.sw360_url: str = os.environ.get("SW360ServerUrl", "")
@@ -70,14 +72,17 @@ class FindSources(capycli.common.script_base.ScriptBase):
         return False
 
     @staticmethod
-    def github_request(url: str, username: str = "", token: str = "") -> Any:
+    def github_request(url: str, username: str = "", token: str = "",
+                       return_response: bool = False,
+                       allow_redirects: bool = True,  # default in requests
+            ) -> Any:
         try:
             headers = {}
             if token:
                 headers["Authorization"] = "token " + token
             if username:
                 headers["Username"] = username
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, allow_redirects=allow_redirects)
             if not response.ok:
                 if response.status_code == 429 or \
                         'rate limit exceeded' in response.reason or \
@@ -87,17 +92,16 @@ class FindSources(capycli.common.script_base.ScriptBase):
                         "      Github API rate limit exceeded - wait 60s and retry ... " +
                         Style.RESET_ALL)
                     time.sleep(60)
-                    return FindSources.github_request(url, username, token)
-
-            return response.json()
+                    return FindSources.github_request(url, username, token, return_response=return_response)
 
         except Exception as ex:
             print(
                 Fore.LIGHTYELLOW_EX +
                 "      Error accessing GitHub: " + repr(ex) +
                 Style.RESET_ALL)
-
-            return {}
+            response = requests.Response()
+            response._content = f'{"exception": "{repr(ex)}"}'.encode()
+        return response if return_response else response.json()
 
     @staticmethod
     def get_repositories(name: str, language: str, username: str = "", token: str = "") -> Any:
@@ -157,6 +161,274 @@ class FindSources(capycli.common.script_base.ScriptBase):
             tags.extend(tmp)
         return tags
 
+    def github_api_request(self, url, **kwargs):
+        """Non static method to query GitHub. Also using slightly
+           different headers.
+           ToDo: not relevant to the topic at hand
+        """
+        headers = {'Accept': 'application/vnd.github+json',
+                   'Authorization': f'Bearer {self.github_token}',
+                   'X-GitHub-Api-Version': '2022-11-28',
+                  }
+        if self.github_name:
+            headers["Username"] = self.github_name
+        method = kwargs.get('method', 'GET')
+        handle_429 = bool(kwargs.get('handle_429', False))
+        req_kwargs = {}
+        # extend the tuple to enable more request.request kwargs
+        for key in ('allow_redirects',
+                ):
+            if key in kwargs:
+                req_kwargs[key] = kwargs[key]
+        try:
+            res = requests.request(method, url, headers=headers, **req_kwargs)
+            if res.status_code == 429 and handle_429 is True\
+            or 'rate limit exceeded' in res.reason \
+            or "API rate limit exceeded" in res.json().get("message"):
+                print(f"{Fore.LIGHTYELLOW_EX}"
+                       "      Github API rate limit exceeded"
+                       " - wait 60s and retry ... "
+                      f"{Style.RESET_ALL}")
+                time.sleep(60)
+                return self.github_api_request(url, **kwargs)
+        except Exception as ex:
+            print(
+                Fore.LIGHTYELLOW_EX +
+                "      Error accessing GitHub: " + repr(ex) +
+                Style.RESET_ALL)
+            res = requests.Response()
+        return res
+
+    def _get_github_repo(self, github_ref):
+        """Fetch GitHub API object identified by @github_ref.
+           @github_ref could be a simple "<owner>/<repo>" string or any
+           kind of the plethora of links that refer to a project on
+           GitHub. This method interpretes @github_ref and fetches the
+           referenced project's data from GitHub.
+        """
+        url = 'api.github.com/repos/'
+        gh_ref = urlparse(github_ref, scheme='no_scheme_provided')
+        if gh_ref.scheme == 'no_scheme_provided':
+            # interprete @github_ref as OWNER/REPO
+            url += gh_ref.path
+        else:
+            # there is an actual <scheme>:// in @github_ref
+            if not gh_ref.netloc.endswith('github.com'):
+                raise ValueError(f'{github_ref} is not an expected @github_ref!')
+            if gh_ref.path.startswith('/repos'):
+                url += gh_ref.path[6:]
+            else:
+                url += gh_ref.path
+        if url.endswith('.git'):
+            url = url[0:-4]
+        url = url.replace('//', '/')  # this is why add https:// late
+        url = f'https://{url}'
+        repo = {}
+        while 'tags_url' not in repo and 'github.com' in url:
+            repo = self.github_request(url, self.github_name, self.github_token)
+            url = url.rsplit('/', 1)[0]  # remove last path segment
+        if 'tags_url' not in repo:
+            raise ValueError(f"Unable to make @github_ref {github_ref} work!")
+        return repo
+
+    def _get_link(self, link, which='next'):
+        """Helper to read link-Header from GitHub API responses."""
+        for match in self.github_header_link_regex.findall(link):
+            try:
+                rel = match[2] + match[3] + match[4]  # two of these will be empty
+                if rel == which:
+                    return match[0]
+            except IndexError:
+                print(f'_get_link unable to match! |{link}|   |{which}|')
+                print(match)
+                print(self.github_header_link_regex.findall(link))
+
+        return None
+
+    def _get_link_page(self, link, which='next'):
+        """Helper to only get page number from link-Header."""
+        url = urlparse(self._get_link(link, which))
+        try:
+            return parse_qs(url.query)['page'][0]
+        except KeyError:  # no page in query
+            return 1
+
+    @staticmethod
+    def trailing_zeroes(data):
+        """Count length of klongest all 0 suffix in @data"""
+        cnt = 0
+        for letter in reversed(data):
+            if letter == '0':
+                cnt += 1
+            else:
+                break
+        return cnt
+
+    def version_to_github_tag(self, version, github_ref, version_prefix=None):
+        """Heuristics to find a tag in GitHub that corresponds to
+           @version in the project identified by @github_ref.
+
+           First we must normalize @github_ref, because we are unsure
+           what is actually passed as this paramter. Using urlparse()
+           we save ourselves a little bit of work with trailing
+           queries and fragments, but any @github_ref with colons where
+           the first colon is not part of '://' will not yield viable
+           results, e.g. 'api.github.com:443/repos/sw360/capycli'.
+
+           Then we start guessing tags.
+           We only care about such tags that produce a non empty match
+           with self.version_regex, because only these would ever yield
+           accepted compare() results in get_matching_tag(). Every such
+           tag can be read as a fixed prefix, a substring as matched by
+           self.version_regex followed by a suffix. Usually, prefix
+           will be "v" and the suffix will be empty, but sometimes tags
+           are more elaborate.
+           We expect the only the regex-matchable part of a tag changes
+           from version to version, while the prefix and the suffix are
+           static.
+           Given a tag with a static prefix, a static suffix and a
+           self.version_regex-matchable substring, we can generate
+           tag names from semantic versions, by reverseing the logic
+           implemented in to_semver_string().
+           Comparing the original matchable substring, to the result of
+           to_semver_string() we should be able to generate similar
+           matchable substrings from @version.
+        """
+        matching_tag = ''
+        semcmp = self.to_semver_string(version).split('.')
+        repo = self._get_github_repo(github_ref)
+        print(f"version_to_github_tag: {github_ref} -> {repo['tags_url']}")
+
+
+        url = repo['tags_url'] +'?per_page=100'
+        res = self.github_request(url, self.github_name,
+                self.github_token, return_response=True)
+        pages = self._get_link_page(res.headers.get('link', ''), 'last')
+        try:
+            for _ in range(pages):
+                #  note: in res.json() we already have the first page
+                tags = [tag['name'] for tag in res.json()]
+                prefix = None
+                suffix = None
+                for tag in tags:
+                    # ex: tag['name'] = foo01_02_03bar
+                    try:
+                        best_guess = self.version_regex.search(tag).group(0)
+                    except AttributeError as err:
+                        print(f'AttributeError {err}')
+                        print(f'    tag: {tag}')
+                        best_guess = tag
+                    # ex => best_guess = 01_02_03
+                    _prefix, _suffix = tag.split(best_guess, 1)
+                    # ex => _prefix = foo, _suffix = bar
+                    if prefix == _prefix and suffix == _suffix:
+                        continue
+                    prefix, suffix = _prefix, _suffix
+
+                    semtag = self.to_semver_string(tag).split('.')
+                    # ex => semtag = ['1', '2', '3']
+
+                    # reverse engineer version string in tag
+                    # ex => semcmp = ['4', '5', '6']
+                    ver_str_parts = []
+                    remainder = best_guess
+                    # if i read that correctly to_semver_string() can return
+                    # versions with more than 3 components
+                    for tag_ver, param_ver in zip(semtag, semcmp):
+                        try:
+                            chunk, remainder = remainder.split(tag_ver, 1)
+                            leading_zeroes = self.trailing_zeroes(chunk)
+                            delta_digits = len(param_ver) - len(tag_ver)
+                            if leading_zeroes > 0 \
+                            and leading_zeroes - delta_digits > 0:
+                                chunk = chunk[:-leading_zeroes]\
+                                      + '0' * (leading_zeroes - delta_digits)
+                            ver_str_parts.append(chunk)
+                            ver_str_parts.append(param_ver)
+                            # ex => ver_str_parts = ['0', '4', '_0', '5', '_0', '6']
+                        except ValueError as err:
+                            # sometimes there are wonky tags that are not
+                            # even meant to be a release
+                            # print(f'ValueError {err}')
+                            # print(f'    best_guess: {best_guess}')
+                            # print(f'    remainder: {remainder}')
+                            # print('    ', semtag, semcmp)
+                            # print('    ', tag_ver, param_ver)
+                            # print('    ', ver_str_parts)
+                            pass
+
+                    guesses = {  # avoid generating duplicates
+                        prefix + ''.join(ver_str_parts) + suffix,  # ex => foo04_05_06bar
+                        prefix + ''.join(ver_str_parts),
+                        'v' + ''.join(ver_str_parts),
+                        ''.join(ver_str_parts),
+                        prefix + '.'.join(semcmp) + suffix,
+                        prefix + '.'.join(semcmp),
+                        'v' + '.'.join(semcmp),
+                        '.'.join(semcmp),
+                    }
+                    for guess in guesses:
+                        print(f'version_to_github_tag: {tag} {guess} ', end='')
+                        if guess in tags:
+                            print('found on current page')
+                            matching_tag = guess
+                            raise StopIteration()
+                        url = repo['git_refs_url'].replace('{/sha}', '{sha}', 1)
+                        url = url.format(sha='/tags/' + guess)
+                        res = self.github_request(url, self.github_name,
+                                self.github_token, return_response=True)
+                        if res.status_code == 200:
+                            print('is a valid tag')
+                            matching_tag = guess
+                            raise StopIteration()
+                        print(':-(')
+
+                try:
+                    url = self._get_link(res.headers['link'], 'next')
+                    if url is None:
+                        raise StopIteration()
+                except KeyError as err:
+                    raise StopIteration() from err
+                res = self.github_request(url, self.github_name,
+                        self.github_token, return_response=True)
+                print('version_to_github_tag: next page!')
+        except StopIteration:
+            pass
+
+        if matching_tag == '':
+            print_yellow("      No matching tag for version " + version + " found ")
+            return ""
+
+        url = repo['archive_url'].replace('{/ref}', '{ref}', 1)
+        url = url.format(archive_format='tarball', ref='/'+matching_tag)
+        res = self.github_request(url, self.github_name, self.github_token,
+                                return_response=True, allow_redirects=False)
+        try:
+            return res.headers['location']
+        except KeyError:
+            print(f'No location in response! {url} {res.status_code}')
+            print(res.headers)
+        return ""  # fail
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def to_semver_string(self, version: str) -> str:
         """Bring all version information to a format we can compare."""
         result = self.version_regex.search(version)
@@ -194,7 +466,10 @@ class FindSources(capycli.common.script_base.ScriptBase):
         if len(name_match):
             for match in name_match:
                 tag_info = self.github_request(match["tags_url"], self.github_name, self.github_token)
+                print(f'find_github_url version_to_github_tag {component.version} {match["tags_url"]}')
+                new_style = self.version_to_github_tag(component.version, match["tags_url"])
                 source_url = self.get_matching_tag(tag_info, component.version or "", match["html_url"])
+                print(f'UPGRADE find_github_url{new_style == source_url} old({source_url}) new({new_style})')
                 if len(name_match) == 1:
                     return source_url
                 elif source_url:
@@ -261,10 +536,13 @@ class FindSources(capycli.common.script_base.ScriptBase):
 
                 if repository_name.startswith("https://github.com/"):
                     repository_name = repository_name[len("https://github.com/"):]
+                print(f'find_golang_url version_to_github_tag {component_version} {repository_name}')
+                new_style = self.version_to_github_tag(component_version, repository_name)
                 tag_info = self.get_github_info(repository_name, self.github_name, self.github_token)
                 tag_info_checked = self.check_for_github_error(tag_info)
                 source_url = self.get_matching_tag(tag_info_checked, component_version,
                                                    repository_name, version_prefix or "")
+                print(f'UPGRADE {new_style == source_url} old({source_url}) new({new_style})')
 
         # component["RepositoryUrl"] = repository_name
         return source_url
@@ -284,10 +562,13 @@ class FindSources(capycli.common.script_base.ScriptBase):
 
         if self.verbose:
             print_text("      repo_name:", repo_name)
-
+        print(f'get_github_source_url version_to_github_tag {version} {repo_name}')
+        new_style = self.version_to_github_tag(version, repo_name)
         tag_info = self.get_github_info(repo_name, self.github_name, self.github_token)
         tag_info_checked = self.check_for_github_error(tag_info)
-        return self.get_matching_tag(tag_info_checked, version, github_url)
+        source_url = self.get_matching_tag(tag_info_checked, version, github_url)
+        print(f'UPGRADE {new_style == source_url} old({source_url}) new({new_style})')
+        return source_url
 
     def check_for_github_error(self, tag_info: get_github_info_type) -> List[Dict[str, Any]]:
         if isinstance(tag_info, list):


### PR DESCRIPTION
This PR addresses https://github.com/sw360/capycli/issues/99 and introduces code intended to replace the current combination of `get_github_info()` followed by `get_matching_tag()` which exists only in `capycli.bom.findsources`.

This approach first tries to match a tag using the original `get_matching_tag()`. If all the guessing does not yield any results, the algo implicitly falls back to analyzing each tag with `get_matching_tag()`.