### PR TITLE
fix bug triggering #117, leading to loosing components during "bom map"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@
   to SPECIFIC of to the value given by `-pms`. Now **existing** Project Mainline States are kept.
 * `project create` has a new parameter `--copy_from` which allows to first create a copy of the given
   project and then update the releases based on the contents of the given SBOM.
+* fix for `bom map` loosing SBOM items when it tries to map to invalid SW360 releases
 
 ## 2.6.0
 

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -375,9 +375,13 @@ class MapBom(capycli.common.script_base.ScriptBase):
 
             # Sorted alternatives in descending version order
             # Please note: the release list sometimes contain just the href but no version
-            rel_list = sorted(rel_list,
-                              key=lambda x: "version" in x and ComparableVersion(
-                                  x.get("version", "")), reverse=True)  # type: ignore
+            try:
+                rel_list = sorted(rel_list,
+                                  key=lambda x: "version" in x and ComparableVersion(
+                                      x.get("version", "")), reverse=True)  # type: ignore
+            except ValueError:
+                pass  # we can live with an unsorted list
+
             for relref in rel_list:
                 href = relref["_links"]["self"]["href"]
                 real_release = self.client.get_release_by_url(href)
@@ -779,7 +783,11 @@ class MapBom(capycli.common.script_base.ScriptBase):
                 newbom.components.add(newitem)
 
             # Sorted alternatives in descending version order
-            item.releases = sorted(item.releases, key=lambda x: ComparableVersion(x['Version']), reverse=True)
+            try:
+                item.releases = sorted(item.releases, key=lambda x: ComparableVersion(x['Version']), reverse=True)
+            except ValueError:
+                pass  # we can live with an unsorted list
+
             for match_item in item.releases:
                 if self.is_good_match(match_item["MapResult"]):
                     newitem = self.update_bom_item(item.component, match_item)

--- a/capycli/common/comparable_version.py
+++ b/capycli/common/comparable_version.py
@@ -31,6 +31,7 @@ class ComparableVersion:
             self.parts = self.parse(version)
         except Exception:
             LOG.warning("Unable to parse version %s", version)
+            raise  # pass on to caller as object is useless without self.parts
 
     @staticmethod
     def parse(version: str) -> List[Tuple[bool, int | str]]:

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -178,7 +178,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
-        # TODO see #25: assert len(res.releases) == 1
+        # TODO see #118: assert len(res.releases) == 1
 
         component_matches = {"_embedded": {"sw360:components": [
             {"name": "Mail",

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -191,6 +191,38 @@ class CapycliTestBomMap(CapycliTestBase):
         assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
         assert len(res.releases) == 1
 
+    @responses.activate
+    def test_map_bom_item_nocache_invalid_version(self) -> None:
+        bomitem = Component(
+            name="mail",
+            version="1.4")
+        component_matches = {"_embedded": {"sw360:components": [
+            {"name": "mail",
+             "_links": {"self": {"href": SW360_BASE_URL + 'components/b001'}}}]}}
+        component_data1 = {"_embedded": {"sw360:releases": [
+            {"version": "1.4",
+             "_links": {"self": {"href": SW360_BASE_URL + 'releases/1111'}}},
+            {"version": "1.0._ME-2",
+             "_links": {"self": {"href": SW360_BASE_URL + 'releases/1112'}}}]}}
+        release_data1 = {"name": "mail", "version": "1.4", "_links": {
+            "self": {"href": SW360_BASE_URL + 'releases/1111'},
+            "sw360:component": {"href": SW360_BASE_URL + "components/b001"}}}
+        release_data2 = {"name": "Mail", "version": "1.0._ME-2", "_links": {
+            "self": {"href": SW360_BASE_URL + 'releases/1112'},
+            "sw360:component": {"href": SW360_BASE_URL + "components/b002"}}}
+        responses.add(responses.GET, SW360_BASE_URL + 'components?name=mail',
+                      json=component_matches)
+        responses.add(responses.GET, SW360_BASE_URL + 'components/b001',
+                      json=component_data1)
+        responses.add(responses.GET, SW360_BASE_URL + 'releases/1111',
+                      json=release_data1)
+        responses.add(responses.GET, SW360_BASE_URL + 'releases/1112',
+                      json=release_data2)
+
+        res = self.app.map_bom_item_no_cache(bomitem)
+        assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
+        assert len(res.releases) == 1
+
     # ----------------- map_bom_item_no_cache purl cases --------------------
 
     @responses.activate


### PR DESCRIPTION
As described in #117, invalid SW360 version numbers (which can't be parsed by ComparableVersion) lead to an exception caught quite late, leading to "bom map" forgetting a component in the output BOM. 

This PR makes the exception being caught in time, but in my eyes doesn't completely fix #117 as other exceptions in the long code base of map_bom_* can lead to the same problem, so we should still discuss error handling in #117.