### PR TITLE
avoid "Restoring original project mainline states" during "project update"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,11 +14,12 @@
 * CaPyCLI now supports color console output also when running in GitLab CI.
 * `bom map` fix: In few cases with --nocache, it added mixed matches to output
   BOM, now we assure that only the best mapping results are added.
+* `project createbom` stores release relations (`CONTAINED`, `SIDE_BY_SIDE` etc.) as capycli:projectRelation
 
 ## 2.7.0
 
 * fix for `bom findsources` for some JavaScript SBOMs.
-* `bom show` command also lists purl and source code download url in verbose mode.  
+* `bom show` command also lists purl and source code download url in verbose mode.
   If one of the values is missing and `--forceerror` has been specified, error code 97 is returned.
 * `bom show` command also lists license information in verbose mode, but
   only for CycloneDX 1.6 and later.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@
 * `bom map` fix: In few cases with --nocache, it added mixed matches to output
   BOM, now we assure that only the best mapping results are added.
 * `project createbom` stores release relations (`CONTAINED`, `SIDE_BY_SIDE` etc.) as capycli:projectRelation
+* `project update`: optimized handling of release mainline state and release relation. Now states
+  provided in the SBOM are used and slowdowns/crashes introduced in 2.7.0 (#121) fixed again.
 
 ## 2.7.0
 

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -66,6 +66,7 @@ class CycloneDxSupport():
     CDX_PROP_CLEARING_STATE = "capycli:clearingState"
     CDX_PROP_CATEGORIES = "capycli:categories"
     CDX_PROP_PROJ_STATE = "capycli:projectClearingState"
+    CDX_PROP_PROJ_RELATION = "capycli:projectRelation"
     CDX_PROP_PROFILE = "siemens:profile"
 
     @staticmethod

--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -33,9 +33,9 @@ class CreateProject(capycli.common.script_base.ScriptBase):
         self.onlyUpdateProject = onlyUpdateProject
         self.project_mainline_state: str = ""
 
-    def bom_to_release_list(self, sbom: Bom) -> List[str]:
-        """Creates a list with linked releases"""
-        linkedReleases = []
+    def bom_to_release_list(self, sbom: Bom) -> Dict[str, Any]:
+        """Creates a list with linked releases from the SBOM."""
+        linkedReleases: Dict[str, Any] = {}
 
         for cx_comp in sbom.components:
             rid = CycloneDxSupport.get_property_value(cx_comp, CycloneDxSupport.CDX_PROP_SW360ID)
@@ -45,31 +45,39 @@ class CreateProject(capycli.common.script_base.ScriptBase):
                     + ", " + str(cx_comp.version))
                 continue
 
-            linkedReleases.append(rid)
+            linkedReleases[rid] = {}
+
+            mainlineState = CycloneDxSupport.get_property_value(cx_comp, CycloneDxSupport.CDX_PROP_PROJ_STATE)
+            if mainlineState:
+                linkedReleases[rid]["mainlineState"] = mainlineState
+            relation = CycloneDxSupport.get_property_value(cx_comp, CycloneDxSupport.CDX_PROP_PROJ_RELATION)
+            if relation:
+                # No typo. In project structure, it's "relation", while release update API uses "releaseRelation".
+                linkedReleases[rid]["releaseRelation"] = relation
 
         return linkedReleases
 
-    def get_release_project_mainline_states(self, project: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        pms: List[Dict[str, Any]] = []
+    def merge_project_mainline_states(self, data: Dict[str, Any], project: Optional[Dict[str, Any]]) -> None:
         if not project:
-            return pms
+            return
 
         if "linkedReleases" not in project:
-            return pms
+            return
 
         for release in project["linkedReleases"]:  # NOT ["sw360:releases"]
             pms_release = release.get("release", "")
             if not pms_release:
                 continue
+            pms_release = pms_release.split("/")[-1]
+            if pms_release not in data:
+                continue
             pms_state = release.get("mainlineState", "OPEN")
             pms_relation = release.get("relation", "UNKNOWN")
-            pms_entry: Dict[str, Any] = {}
-            pms_entry["release"] = pms_release
-            pms_entry["mainlineState"] = pms_state
-            pms_entry["new_relation"] = pms_relation
-            pms.append(pms_entry)
 
-        return pms
+            if "mainlineState" not in data[pms_release]:
+                data[pms_release]["mainlineState"] = pms_state
+            if "releaseRelation" not in data[pms_release]:
+                data[pms_release]["releaseRelation"] = pms_relation
 
     def update_project(self, project_id: str, project: Optional[Dict[str, Any]],
                        sbom: Bom, project_info: Dict[str, Any]) -> None:
@@ -79,7 +87,7 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)
 
         data = self.bom_to_release_list(sbom)
-        pms = self.get_release_project_mainline_states(project)
+        self.merge_project_mainline_states(data, project)
 
         ignore_update_elements = ["name", "version"]
         # remove elements from list because they are handled separately
@@ -90,13 +98,17 @@ class CreateProject(capycli.common.script_base.ScriptBase):
         try:
             print_text("  " + str(len(data)) + " releases in SBOM")
 
+            update_mode = self.onlyUpdateProject
             if project and "_embedded" in project and "sw360:releases" in project["_embedded"]:
                 print_text(
                     "  " + str(len(project["_embedded"]["sw360:releases"])) +
                     " releases in project before update")
+            else:
+                # Workaround for SW360 API bug: add releases will hang forever for empty projects
+                update_mode = False
 
             # note: type in sw360python, 1.4.0 is wrong - we are using the correct one!
-            result = self.client.update_project_releases(data, project_id, add=self.onlyUpdateProject)  # type: ignore
+            result = self.client.update_project_releases(data, project_id, add=update_mode)  # type: ignore
             if not result:
                 print_red("  Error updating project releases!")
             project = self.client.get_project(project_id)
@@ -113,20 +125,6 @@ class CreateProject(capycli.common.script_base.ScriptBase):
                 result2 = self.client.update_project(project_info, project_id, add_subprojects=self.onlyUpdateProject)
                 if not result2:
                     print_red("  Error updating project!")
-
-            if pms and project:
-                print_text("  Restoring original project mainline states...")
-                for pms_entry in pms:
-                    update_release = False
-                    for r in project.get("linkedReleases", []):
-                        if r["release"] == pms_entry["release"]:
-                            update_release = True
-                            break
-
-                    if update_release:
-                        rid = self.client.get_id_from_href(pms_entry["release"])
-                        self.client.update_project_release_relationship(
-                            project_id, rid, pms_entry["mainlineState"], pms_entry["new_relation"], "")
 
         except SW360Error as swex:
             if swex.response is None:

--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -353,6 +353,7 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             sys.exit(ResultCode.RESULT_FILE_NOT_FOUND)
 
         is_update_version = False
+        project = None
 
         if args.old_version and args.old_version != "":
             print_text("Project version will be updated with version: " + args.old_version)
@@ -413,7 +414,8 @@ class CreateProject(capycli.common.script_base.ScriptBase):
         if self.project_id:
             print("Updating project...")
             try:
-                project = self.client.get_project(self.project_id)
+                if project is None:
+                    project = self.client.get_project(self.project_id)
             except SW360Error as swex:
                 print_red("  ERROR: unable to access project:" + repr(swex))
                 sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)

--- a/tests/fixtures/sbom_for_create_project.json
+++ b/tests/fixtures/sbom_for_create_project.json
@@ -67,6 +67,10 @@
           "value": "Python"
         },
         {
+          "name": "capycli:projectRelation",
+          "value": "DYNAMICALLY_LINKED"
+        },
+        {
           "name": "siemens:sw360Id",
           "value": "a5cae39f39db4e2587a7d760f59ce3d0"
         }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -214,10 +214,10 @@ class TestBasePytest:
                 {
                     "createdBy": "thomas.graf@siemens.com",
                     "release": "https://my.server.com/resource/api/releases/r002",
-                    "mainlineState": "SPECIFIC",
+                    "mainlineState": "MAINLINE",
                     "comment": "Automatically updated by SCC",
                     "createdOn": "2023-03-14",
-                    "relation": "UNKNOWN"
+                    "relation": "DYNAMICALLY_LINKED"
                 }
             ],
             "_links": {

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -230,6 +230,16 @@ class TestCreateBom(TestBasePytest):
         assert len(ext_refs_vcs) == 1
         assert str(ext_refs_vcs[0].url) == release["repository"]["url"]
 
+        prj_ml_state = CycloneDxSupport.get_property(cx_comp, CycloneDxSupport.CDX_PROP_PROJ_STATE)
+        assert prj_ml_state.value == "MAINLINE"
+        releaseRelation = CycloneDxSupport.get_property(cx_comp, CycloneDxSupport.CDX_PROP_PROJ_RELATION)
+        assert releaseRelation.value == "DYNAMICALLY_LINKED"
+
+        prj_ml_state = CycloneDxSupport.get_property(cdx_bom.components[1], CycloneDxSupport.CDX_PROP_PROJ_STATE)
+        assert prj_ml_state.value == "SPECIFIC"
+        releaseRelation = CycloneDxSupport.get_property(cdx_bom.components[1], CycloneDxSupport.CDX_PROP_PROJ_RELATION)
+        assert releaseRelation.value == "UNKNOWN"
+
         assert cdx_bom.metadata.component is not None
         if cdx_bom.metadata.component:
             assert cdx_bom.metadata.component.name == project["name"]

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -426,9 +426,14 @@ class TestCreateProject(TestBase):
                 "visibility": "EVERYONE",
                 "_links": {
                     "self": {
-                        "href": TestBase.MYURL + "resource/api/projects/376576"
+                        "href": TestBase.MYURL + "resource/api/projects/007"
                     }
                 },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "UNKNOWN",
+                }],
                 "_embedded": {
                     "sw360:releases": [{
                         "name": "Angular 2.3.0",
@@ -493,6 +498,173 @@ class TestCreateProject(TestBase):
         responses.add(
             responses.PATCH,
             url=self.MYURL + "resource/api/projects/007",
+            json={
+                # server returns complete project, here we only mock a part of it
+                "name": "CaPyCLI",
+                "veraion": "1.9.0",
+                "businessUnit": "SI",
+                "description": "CaPyCLI",
+                "linkedReleases": {
+                    "a5cae39f39db4e2587a7d760f59ce3d0": {
+                        "mainlineState": "SPECIFIC",
+                        "releaseRelation": "DYNAMICALLY_LINKED",
+                        "setMainlineState": True,
+                        "setReleaseRelation": True
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": self.MYURL + "resource/api/projects/007"
+                    }
+                },
+                "_embedded": {
+                    "sw360:releases": [{
+                        "name": "Angular 2.3.0",
+                        "version": "2.3.0",
+                        "_links": {
+                            "self": {
+                                "href": "https://sw360.org/api/releases/3765276512"
+                            }
+                        }
+                    }]
+                }
+            },
+            match=[
+                min_json_matcher(
+                    {
+                        "businessUnit": "SI",
+                        "description": "CaPyCLI",
+                        "ownerGroup": "SI",
+                        "projectOwner": "thomas.graf@siemens.com",
+                        "projectResponsible": "thomas.graf@siemens.com",
+                        "projectType": "INNER_SOURCE",
+                        "tag": "SI BP DB Demo",
+                        "visibility": "EVERYONE"
+                    })
+            ],
+            status=201,
+            content_type="application/json",
+            adding_headers={"Authorization": "Token " + self.MYTOKEN},
+        )
+
+        out = self.capture_stdout(sut.run, args)
+        self.assertTrue(self.INPUTFILE in out)
+
+    @responses.activate
+    def test_project_copy_from(self) -> None:
+        """copy project 007 to 017"""
+        sut = CreateProject()
+
+        # create argparse command line argument object
+        args = AppArguments()
+        args.command = []
+        args.command.append("project")
+        args.command.append("create")
+        args.sw360_token = TestBase.MYTOKEN
+        args.sw360_url = TestBase.MYURL
+        args.version = "2.0.0"
+        args.copy_from = "007"
+        args.inputfile = os.path.join(os.path.dirname(__file__), "fixtures", self.INPUTFILE)
+        args.verbose = True
+        args.debug = True
+
+        self.add_login_response()
+
+        new_project_json = {
+            "name": "CaPyCLI",
+            "version": "2.0.0",
+            "securityResponsibles": [],
+            "considerReleasesFromExternalList": False,
+            "projectType": "PRODUCT",
+            "visibility": "EVERYONE",
+            "_links": {
+                "self": {
+                    "href": TestBase.MYURL + "resource/api/projects/017"
+                }
+            },
+            "linkedReleases": [{
+                "release": "https://sw360.org/api/releases/a5cae39f39db4e2587a7d760f59ce3d0",
+                "mainlineState": "SPECIFIC",
+                "relation": "UNKNOWN",
+            }],
+            "_embedded": {
+                "sw360:releases": [{
+                    "name": "charset-normalizer",
+                    "version": "3.1.0",
+                    "_links": {
+                        "self": {
+                            "href": "https://sw360.org/api/releases/a5cae39f39db4e2587a7d760f59ce3d0",
+                        }
+                    }
+                }]
+            }
+        }
+
+        responses.add(
+            responses.POST,
+            url=self.MYURL + "resource/api/projects/duplicate/007",
+            json=new_project_json,
+            status=200,
+            content_type="application/json",
+            adding_headers={"Authorization": "Token " + self.MYTOKEN},
+        )
+
+        responses.add(
+            responses.GET,
+            url=self.MYURL + "resource/api/projects/017",
+            json=new_project_json,
+            status=200,
+            content_type="application/json",
+            adding_headers={"Authorization": "Token " + self.MYTOKEN},
+        )
+
+        # update project releases
+        responses.add(
+            responses.POST,
+            url=self.MYURL + "resource/api/projects/017/releases",
+            json={
+                # server returns complete project, here we only mock a part of it
+                "name": "CaPyCLI",
+                "veraion": "1.9.0",
+                "businessUnit": "SI",
+                "description": "CaPyCLI",
+                "linkedReleases": {
+                    "a5cae39f39db4e2587a7d760f59ce3d0": {
+                        "mainlineState": "SPECIFIC",
+                        "releaseRelation": "DYNAMICALLY_LINKED",
+                        "setMainlineState": True,
+                        "setReleaseRelation": True
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": self.MYURL + "resource/api/projects/007"
+                    }
+                },
+                "_embedded": {
+                    "sw360:releases": [{
+                        "name": "Angular 2.3.0",
+                        "version": "2.3.0",
+                        "_links": {
+                            "self": {
+                                "href": "https://sw360.org/api/releases/3765276512"
+                            }
+                        }
+                    }]
+                }
+            },
+            match=[
+                update_release_matcher(["a5cae39f39db4e2587a7d760f59ce3d0"])
+            ],
+            status=201,
+            content_type="application/json",
+            adding_headers={"Authorization": "Token " + self.MYTOKEN},
+        )
+
+        # update project
+        responses.add(
+            responses.PATCH,
+            url=self.MYURL + "resource/api/projects/017",
             json={
                 # server returns complete project, here we only mock a part of it
                 "name": "CaPyCLI",

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -461,14 +461,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.0",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/007"
@@ -504,14 +501,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.0",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/007"
@@ -628,14 +622,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.0",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/007"
@@ -671,14 +662,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.0",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/007"
@@ -780,14 +768,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.9",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/008"
@@ -823,14 +808,11 @@ class TestCreateProject(TestBase):
                 "veraion": "1.9.0",
                 "businessUnit": "SI",
                 "description": "CaPyCLI",
-                "linkedReleases": {
-                    "a5cae39f39db4e2587a7d760f59ce3d0": {
-                        "mainlineState": "SPECIFIC",
-                        "releaseRelation": "DYNAMICALLY_LINKED",
-                        "setMainlineState": True,
-                        "setReleaseRelation": True
-                    }
-                },
+                "linkedReleases": [{
+                    "release": "https://sw360.org/api/releases/3765276512",
+                    "mainlineState": "SPECIFIC",
+                    "relation": "DYNAMICALLY_LINKED",
+                }],
                 "_links": {
                     "self": {
                         "href": self.MYURL + "resource/api/projects/007"

--- a/tests/test_show_project.py
+++ b/tests/test_show_project.py
@@ -168,7 +168,7 @@ class TestShowProject(TestBase):
         self.assertTrue("Project owner: thomas.graf@siemens.com" in out)
         self.assertTrue("Clearing state: IN_PROGRESS" in out)
         self.assertTrue("No linked projects" in out)
-        self.assertTrue("cli-support, 1.3 = SPECIFIC, APPROVED" in out)
+        self.assertTrue("cli-support, 1.3 = MAINLINE, APPROVED" in out)
         self.assertTrue("wheel, 0.38.4 = SPECIFIC, APPROVED" in out)
 
     @responses.activate
@@ -337,7 +337,7 @@ class TestShowProject(TestBase):
         self.assertTrue("Clearing state: IN_PROGRESS" in out)
         self.assertTrue("Linked projects:" in out)
         self.assertTrue("sub-project-dummy, 2.0.1" in out)
-        self.assertTrue("cli-support, 1.3 = SPECIFIC, APPROVED" in out)
+        self.assertTrue("cli-support, 1.3 = MAINLINE, APPROVED" in out)
         self.assertTrue("wheel, 0.38.4 = SPECIFIC, APPROVED" in out)
 
         self.assertTrue(os.path.isfile(self.OUTPUTFILE), "no output file generated")


### PR DESCRIPTION
This changes the release state handling during "project update". Instead of storing project release states from SW360 and restoring it release by release at the end, we pass on full release data to REST API endpoint for updating linked releases.

As an SBOM has to be provided during "project update" or "project create --copy_from" anyways, we take the release states stored in the SBOM instead of keeping the state in SW360.

Note that this requires also the change from https://github.com/sw360/sw360python/pull/41 for correct "project update" support. 

Fixes #121 