### PR TITLE
fix: don't crash when CaPyCli installed from branch

### DIFF
--- a/capycli/__init__.py
+++ b/capycli/__init__.py
@@ -53,7 +53,8 @@ def get_app_version() -> str:
     if not version:
         # use version information from poetry
         pkg_meta = _get_project_meta()
-        version = str(pkg_meta['version'])
+        if pkg_meta and 'version' in pkg_meta:
+            version = str(pkg_meta['version'])
 
     if not version:
         version = "0.0.0-no-version"


### PR DESCRIPTION
CaPyCli expects that it's either installed from a stable package or run from a Git clone. If you install it from a branch, e.g. using Poetry, it will crash as it can find neither package metadata nor pyproject.toml.

Fixes #132