### PR TITLE
Update print.py

### DIFF
--- a/capycli/common/print.py
+++ b/capycli/common/print.py
@@ -8,9 +8,13 @@
 
 import datetime
 from typing import Any
+import os
+from colorama import Fore, Style, init
+# Force color support in GitLab CI
+FORCE_COLOR = os.environ.get("CI") == "true" and os.environ.get("GITLAB_CI") == "true"
 
-from colorama import Fore, Style
-
+# Initialize colorama with auto-reset and force mode if in GitLab CI
+init(autoreset=True, strip=not FORCE_COLOR)
 import capycli.common
 
 


### PR DESCRIPTION
Ensures colored logs (red/yellow/green) work in GitLab CI by detecting CI environment and forcing colorama to preserve ANSI codes. Uses `autoreset` and `strip=not FORCE_COLOR` for compatibility.