### PR TITLE
Fix: Relocate capycli.common import to top of print.py to resolve imp…

### DIFF
--- a/capycli/common/print.py
+++ b/capycli/common/print.py
@@ -5,13 +5,13 @@
 #
 # SPDX-License-Identifier: MIT
 # -------------------------------------------------------------------------------
-
+import capycli.common
 import datetime
 from typing import Any
 
 from colorama import Fore, Style
 
-import capycli.common
+
 
 
 def _get_debug_prefix() -> str:


### PR DESCRIPTION
…ort error

Moves the capycli.common import to the top of print.py to resolve import context issues and improve module clarity.