### PR TITLE
✔️ Fixed static check issue (E303: too many blank lines) in print.py

### DIFF
--- a/capycli/common/print.py
+++ b/capycli/common/print.py
@@ -8,11 +8,8 @@
 
 import datetime
 from typing import Any
-
 from colorama import Fore, Style
-
 import capycli.common
-
 
 def _get_debug_prefix() -> str:
     """Returns a prefix similar to the one from logging."""


### PR DESCRIPTION
Now fully PEP8-compliant and ready for recheck.