### PR TITLE
feat(purl_store): allow duplicate purls in cache

### DIFF
--- a/Readme_BOM.md
+++ b/Readme_BOM.md
@@ -46,10 +46,10 @@ namespace or the `capycli` namespace.
 | Key                       | Description                        |
 | ------------------------- | ---------------------------------- |
 | siemens:sw360Id           | SW360 ID (of a release)            |
-| siemens:componentId       | id of a component, part of mapping |
 | siemens:primaryLanguage   | programming language               |
 | siemens:filename          | name of a (source) file            |
 | siemens:profile           | profile/type of the SBOM           |
+| capycli:componentId       | id of a component, part of mapping |
 | capycli:sourceFileType    | SW360 attachment type              |
 | capycli:sourceFileComment | upload comment for SW360 attachment|
 | capycli:mapResult         | mapping result                     |
@@ -80,7 +80,7 @@ Example:
           "value": "Java"
         },
         {
-          "name": "ssiemens:sw360Id ",
+          "name": "siemens:sw360Id",
           "value": "f9159fde78553c2ba192b7fa8e8c2033"
         }
       ]

--- a/Readme_Mapping.md
+++ b/Readme_Mapping.md
@@ -1,5 +1,5 @@
 <!--
-# SPDX-FileCopyrightText: (c) 2018-2024 Siemens
+# SPDX-FileCopyrightText: (c) 2018-2025 Siemens
 # SPDX-License-Identifier: MIT
 -->
 
@@ -32,6 +32,28 @@ informs about the mapping result:
 * **`NO_MATCH` (100)** => Component was not found
 
 In general you can say that the lower the number, the better the match.
+
+## Notes on id mapping / PackageURL mapping
+
+CaPyCli supports mapping releases by the PackageURL. As encoding of a
+PackageURL is not unique (some characters *may* use URL encoding, qualifiers
+can be given in random order etc.), we can't just do a string comparison, but
+instead *all* SW360 releases with PackageURLs (using external id `package-url`)
+are retrieved and decoded. When your input BOM specifies a `purl` field, then
+the PackageURL is compared field by field (type, namespace, name, version) for
+a `FULL_MATCH_BY_ID`.
+
+Also, components will be mapped by PackageURL and if a match is found, the
+`capycli:componentId` property will be added to the output BOM item. Components
+can be identified directly by their external id `package-url` or as fallback
+also by the `package-url`s of their releases.
+
+PackageURL subpath and qualifiers are currently ignored during PURL matching.
+
+Note that we consider PackageURLs as *unique identifier*, so if two releases or
+components have the *same* external ID, a warning will be printed and the
+external ids will be completely ignored and mapping will continue with the
+other search steps like by file hash, by name and version etc.
 
 ## Example 1: Very Simple, Full Match
 

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -368,7 +368,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
             if release_url is not None:
                 rel_list = [{"_links": {"self": {"href": release_url}}}]
             else:
-                comp = self.client.get_component_by_url(compref)  # type: ignore
+                comp = self.client.get_component_by_url(compref)
                 if not comp:
                     continue
                 rel_list = comp["_embedded"].get("sw360:releases", [])
@@ -846,7 +846,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
             cachefile, True, token, oauth2=oauth2, url=sw360_url)
         return rel_data
 
-    def map_bom_commons(self, component: Component) -> Tuple[MapResult, str, str]:
+    def map_bom_commons(self, component: Component) -> Tuple[MapResult, Optional[str], Optional[str]]:
         """
         Common parts to map from a SBOM component to the SW360 component/release.
         :param bomitem: SBOM component

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -53,7 +53,9 @@ class CapycliTestBomMap(CapycliTestBase):
             return
 
         self.app.purl_service = PurlService(self.app.client, cache={'deb': {'debian': {'sed': {
-            None: SW360_BASE_URL + "components/a035"}}}})
+            None: [{
+                "purl": PackageURL("deb", "debian", "sed"),
+                "href": SW360_BASE_URL + "components/a035"}]}}}})
         # different name in release cache
         self.app.releases = [{"Id": "1234", "ComponentId": "a035",
                               "Name": "Unix Stream EDitor", "Version": "1.0",
@@ -94,8 +96,12 @@ class CapycliTestBomMap(CapycliTestBase):
             return
 
         self.app.purl_service = PurlService(self.app.client, cache={'deb': {'debian': {'sed': {
-            None: SW360_BASE_URL + "components/a035",
-            "1.0~1": SW360_BASE_URL + "releases/1234"}}}})
+            None: [{
+                "purl": PackageURL("deb", "debian", "sed"),
+                "href": SW360_BASE_URL + "components/a035"}],
+            "1.0~1": [{
+                "purl": PackageURL("deb", "debian", "sed", version="1.0~1"),
+                "href": SW360_BASE_URL + "releases/1234"}]}}}})
         self.app.releases = [{"Id": "1234", "ComponentId": "a035",
                               "Name": "Unix Stream EDitor", "Version": "1.0+1",
                               "ExternalIds": {
@@ -233,7 +239,9 @@ class CapycliTestBomMap(CapycliTestBase):
             return
 
         self.app.purl_service = PurlService(self.app.client, cache={'deb': {'debian': {'sed': {
-            None: SW360_BASE_URL + "components/a035"}}}})
+            None: [{
+                "purl": PackageURL("deb", "debian", "sed"),
+                "href": SW360_BASE_URL + "components/a035"}]}}}})
         bomitem = Component(
             name="sed",
             version="1.0",
@@ -321,8 +329,12 @@ class CapycliTestBomMap(CapycliTestBase):
             return
 
         self.app.purl_service = PurlService(self.app.client, cache={'deb': {'debian': {'sed': {
-            None: SW360_BASE_URL + "components/a035",
-            "1.0~1": SW360_BASE_URL + "releases/1234"}}}})
+            None: [{
+                "purl": PackageURL("deb", "debian", "sed"),
+                "href": SW360_BASE_URL + "components/a035"}],
+            "1.0~1": [{
+                "purl": PackageURL("deb", "debian", "sed", version="1.0~1"),
+                "href": SW360_BASE_URL + "releases/1234"}]}}}})
         bomitem = Component(
             name="sed",
             version="1.0+1",


### PR DESCRIPTION
This change shall have no visible effect to the user – BOM mapping shall behave as before. But it prepares the lower layers for the changes discussed in #123 and #139:

Don't filter out duplicate versions or components when building up purl cache. Instead, they are now filtered in the PurlService methods search_release_by_external_id and search_component_by_external_id. This change also aligns both methods to return None if nothing is found.

Additionally, the PurlService now offers new methods search_release*s*_by_external_id and search_component*s*_by_external_id which return all candidates including duplicates.

