### PR TITLE
PURL qualifier-based search

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@
 
 # CaPyCli - Clearing Automation Python Command Line Tool for SW360
 
+## NEXT
+
+* `bom map`: The options `--dbx` and `-all` were replaced by `--matchmode`.
+
 ## 2.9.1
 
 * `bom map` will provide the `purl` from SW360 in the output BOM's components

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 ## NEXT
 
 * `bom map`: The options `--dbx` and `-all` were replaced by `--matchmode`.
+* `bom map --matchmode full-search` allows full search for the best possible
+  matches and report all of them, see the discussion in `Readme_Mapping.md`.
 
 ## 2.9.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,8 +8,8 @@
 ## NEXT
 
 * `bom map`: The options `--dbx` and `-all` were replaced by `--matchmode`.
-* `bom map --matchmode full-search` allows full search for the best possible
-  matches and report all of them, see the discussion in `Readme_Mapping.md`.
+* `bom map`: new `--matchmode` options `full-search` (report all best matches) and
+  `qualifier-match` (consider PackageURL qualifiers). See `Readme_Mapping.md`.
 
 ## 2.9.1
 

--- a/Readme_Mapping.md
+++ b/Readme_Mapping.md
@@ -23,7 +23,7 @@ informs about the mapping result:
 
 * **`INVALID` (0)** => Invalid SBOM entry, could not get processed
 * **`FULL_MATCH_BY_ID` (1)** => Full match by identifier
-* **`FULL_MATCH_BY_HASH` (2)** => Full match by source file hash
+* **`FULL_MATCH_BY_HASH` (2)** => Full match by source or binary file hash
 * **`FULL_MATCH_BY_NAME_AND_VERSION` (3)** => Full match by name and version
 * **`MATCH_BY_FILENAME` (4)** => Match by source code filename
 * **`GOOD_MATCH_FOUND`** == `MATCH_BY_FILENAME` => successfully found a sufficiently good match
@@ -31,7 +31,17 @@ informs about the mapping result:
 * **`SIMILAR_COMPONENT_FOUND` (6)** => Component with similar name found, no version check done
 * **`NO_MATCH` (100)** => Component was not found
 
-In general you can say that the lower the number, the better the match.
+We consider lower numbers as better matches. By default, CaPyCli will stop the
+search when a "good" match (match code between 1 and 4) is found and add this
+release to the output BOM. If there are multiple good matches in SW360, the
+output thus depends on the order the results are returned by SW360 (or found in
+the CaPyCli cache).
+
+The "bom map --matchmode full-search" option allows to change that behaviour so that
+CaPyCli will always search through all releases in the API answer or cache, and
+report *all best* matches found. If there are matches by ID, other matches are
+ignored; matches by (source or binary) file hash will win over matches by name
+and version etc.
 
 ## Notes on id mapping / PackageURL mapping
 

--- a/Readme_Mapping.md
+++ b/Readme_Mapping.md
@@ -45,20 +45,36 @@ and version etc.
 
 ## Notes on id mapping / PackageURL mapping
 
-CaPyCli supports mapping releases by the PackageURL. As encoding of a
-PackageURL is not unique (some characters *may* use URL encoding, qualifiers
+CaPyCli supports mapping **releases** by the PackageURL. As encoding of a
+PackageURL is not unique (some characters may be percent-encoded, qualifiers
 can be given in random order etc.), we can't just do a string comparison, but
 instead *all* SW360 releases with PackageURLs (using external id `package-url`)
 are retrieved and decoded. When your input BOM specifies a `purl` field, then
 the PackageURL is compared field by field (type, namespace, name, version) for
 a `FULL_MATCH_BY_ID`.
 
-Also, components will be mapped by PackageURL and if a match is found, the
+Also, **components** will be mapped by PackageURL and if a match is found, the
 `capycli:componentId` property will be added to the output BOM item. Components
 can be identified directly by their external id `package-url` or as fallback
 also by the `package-url`s of their releases.
 
-PackageURL subpath and qualifiers are currently ignored during PURL matching.
+PackageURL **qualifiers** (like `?distro=alpine-3.21&package-id=3a23`) will be
+considered when using `bom map --matchmode qualifier-match`. In some cases,
+qualifiers are essential for correct mapping, but many scanners also include
+non-essential qualifiers in their SBOMs. And the distinction might be
+challenging: while `distro` is crucial for correct mapping of Alpine packages
+(same package release can have different patches in different Alpine releases),
+but for Debian, `distro` is unnecessary since package versions are already
+unique. So we use the following rules to balance accuracy and practicality:
+
+* Only the qualifiers specified in the input BOM are considered during matching,
+  qualifiers only present in SW360 releases are ignored. So you can control
+  matching by removing the unwanted qualifiers in your SBOM.
+* If one or more SW360 releases are found where *all* qualifiers specified in the
+  input BOM match, *only* these releases are added to the output BOM. Otherwise,
+  qualifiers will be ignored, so all release matches will be added.
+
+PackageURL subpath is currently ignored during PURL matching.
 
 ## Example 1: Very Simple, Full Match
 

--- a/capycli/bom/create_components.py
+++ b/capycli/bom/create_components.py
@@ -399,7 +399,7 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
                         bom_purl = packageurl.PackageURL.from_string(
                             data["externalIds"][repository_type])
                         sw360_purls = PurlUtils.get_purl_list_from_sw360_object(release_data)
-                        id_match = PurlUtils.contains(sw360_purls, bom_purl)
+                        id_match = PurlUtils.contains(sw360_purls, bom_purl, compare_qualifiers=True)
                     except ValueError:
                         pass
                     if not id_match:

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -815,9 +815,12 @@ class MapBom(capycli.common.script_base.ScriptBase):
         print("                          all = default, write everything to resulting SBOM")
         print("                          found = resulting SBOM shows only components that were found")
         print("                          notfound = resulting SBOM shows only components that were not found")
-        print("    --dbx                 relaxed Debian version handling: *completely* ignore Debian revision,")
-        print("                          so SBOM version 3.1 will match SW360 version 3.1-3.debian")
-        print("    -all                  also report matches for name, but different version")
+        print("    --matchmode MATCHMODE matching mode, comma separated list of:")
+        print("                          all-versions = also report matches for name, but different version")
+        print("                          ignore-debian = ignore Debian revision in version comparison, so SBOM")
+        print("                                          version 3.1 will match SW360 version 3.1-3.debian")
+        print("    -all                  deprecated, please use --matchmode all-versions")
+        print("    --dbx                 deprecated, please use --matchmode ignore-debian")
 
     def run(self, args: Any) -> None:
         """Main method()"""
@@ -849,14 +852,18 @@ class MapBom(capycli.common.script_base.ScriptBase):
         if args.verbose:
             self.verbosity = 2
 
-        if args.dbx:
+        if "ignore-debian" in args.matchmode or args.dbx:
+            if args.dbx:
+                print_yellow("bom map --dbx is deprecated, use --matchmode ignore-debian instead")
             print_text("Using relaxed debian version checks")
             self.relaxed_debian_parsing = True
 
         if args.mode:
             self.mode = args.mode
 
-        if args.all:
+        if "all-versions" in args.matchmode or args.all:
+            if args.all:
+                print_yellow("bom map -all is deprecated, use --matchmode all-versions instead")
             self.no_match_by_name_only = False
 
         print_text("Loading SBOM file", args.inputfile)

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -60,6 +60,7 @@ class CycloneDxSupport():
     CDX_PROP_COMPONENT_ID = "capycli:componentId"
     CDX_PROP_FILENAME = "siemens:filename"
     CDX_PROP_MAPRESULT = "capycli:mapResult"
+    CDX_PROP_MAPRESULT_BY_ID = "capycli:mapResultById"
     CDX_PROP_SW360_HREF = "capycli:sw360Href"
     CDX_PROP_SW360_URL = "capycli:sw360Url"
     CDX_PROP_REL_STATE = "capycli:releaseMainlineState"

--- a/capycli/common/map_result.py
+++ b/capycli/common/map_result.py
@@ -7,10 +7,18 @@
 # -------------------------------------------------------------------------------
 
 from typing import Any, List, Optional
+from enum import Enum
 
 from cyclonedx.model.component import Component
 
 from capycli.common.capycli_bom_support import CycloneDxSupport
+
+
+class MapResultByIdQualifiers(Enum):
+    FULL_MATCH = "qualifiers-full-match"
+    IGNORED = "qualifiers-ignored"
+    UNKNOWN = "qualifiers-unknown-match"
+    NO_QUALIFIER_MAPPING = ""
 
 
 class MapResult:
@@ -50,7 +58,21 @@ class MapResult:
         self.result: str = MapResult.NO_MATCH
         self._component_hrefs: List[str] = []
         self._release_hrefs: List[str] = []
+        self._release_hrefs_results: List[str] = []
         self.releases: List[Any] = []
+
+    @property
+    def release_hrefs_results(self) -> list[str]:
+        return self._release_hrefs_results
+
+    @release_hrefs_results.setter
+    def release_hrefs_results(self, value: list[str]) -> None:
+        self._release_hrefs_results = value
+        if not self.input_component or not value:
+            return
+        CycloneDxSupport.update_or_set_property(
+            self.input_component, CycloneDxSupport.CDX_PROP_MAPRESULT_BY_ID,
+            " ".join(value))
 
     @property
     def component_hrefs(self) -> List[str]:

--- a/capycli/common/purl_store.py
+++ b/capycli/common/purl_store.py
@@ -6,9 +6,10 @@
 # SPDX-License-Identifier: MIT
 # -------------------------------------------------------------------------------
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from packageurl import PackageURL
+from capycli.common.map_result import MapResultByIdQualifiers
 
 
 class PurlStore:
@@ -84,3 +85,27 @@ class PurlStore:
             return entries[purl.version]
 
         return []
+
+    @staticmethod
+    def filter_by_qualifiers(entries: List[Dict[str, Any]], purl: PackageURL) -> Tuple[MapResultByIdQualifiers,
+                                                                                       List[Dict[str, Any]]]:
+        """
+        Filter entries based on the qualifiers in the given PackageURL and return the match type.
+
+        :param entries: A list of entries to filter as returned by get_by_version.
+        :param purl: The PackageURL object containing qualifiers to match.
+        :return: A tuple (qualifier_result, list of entries)
+        """
+        if not purl.qualifiers or len(entries) == 0:
+            return MapResultByIdQualifiers.NO_QUALIFIER_MAPPING, entries
+
+        assert isinstance(purl.qualifiers, dict)
+        qualifiers_items = purl.qualifiers.items()
+        filtered_entries = [
+            entry for entry in entries
+            if all(entry["purl"].qualifiers.get(key) == value for key, value in qualifiers_items)
+        ]
+
+        if filtered_entries:
+            return MapResultByIdQualifiers.FULL_MATCH, filtered_entries
+        return MapResultByIdQualifiers.IGNORED, entries

--- a/capycli/common/purl_utils.py
+++ b/capycli/common/purl_utils.py
@@ -56,17 +56,23 @@ class PurlUtils:
         return []
 
     @staticmethod
-    def contains(purls: list, search_purl: packageurl.PackageURL) -> bool:  # type: ignore
+    def contains(purls: list, search_purl: packageurl.PackageURL,  # type: ignore
+                 compare_qualifiers: bool = False) -> bool:
         """
         Search the given PackageURL in the provided list
         Important: The matching is only based on type, namespace, name and version.
-        We do not consider qualifiers and subpath.
+        If `compare_qualifiers` is set, the qualifiers present in the search_purl are also checked.
+        We do not consider other qualifiers and subpath.
         """
         for entry in purls:
             if (entry.type == search_purl.type
                     and entry.namespace == search_purl.namespace
                     and entry.name == search_purl.name
                     and entry.version == search_purl.version):
+                if compare_qualifiers and isinstance(search_purl.qualifiers, dict):
+                    for key, value in search_purl.qualifiers.items():
+                        if key not in entry.qualifiers or entry.qualifiers[key] != value:
+                            return False
                 return True
         return False
 

--- a/capycli/main/options.py
+++ b/capycli/main/options.py
@@ -279,7 +279,7 @@ class CommandlineSupport():
             help="source folder or additional source file"
         )
 
-        # special parsing flag for MapBom
+        # special parsing flag for BomCreateComponents
         self.parser.add_argument(
             "--dbx",
             dest="dbx",
@@ -358,6 +358,14 @@ class CommandlineSupport():
             choices=map_modes,
             dest="mode",
             help="specific mode for some commands",
+        )
+
+        # special flag for MapBom
+        self.parser.add_argument(
+            "--matchmode",
+            dest="matchmode",
+            default="",
+            help="see \"bom map --help\"",
         )
 
         # used by bom convert

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -35,6 +35,7 @@ class AppArguments():
         self.help: bool = False
         self.id: str = ""
         self.inputfile: str = ""
+        self.matchmode: str = ""
         self.name: str = ""
         self.ncli: bool = False
         self.nconf: bool = False

--- a/tests/test_purl_store.py
+++ b/tests/test_purl_store.py
@@ -10,6 +10,7 @@ import packageurl
 
 from capycli.common.purl_store import PurlStore
 from tests.test_base import TestBase
+from capycli.common.map_result import MapResultByIdQualifiers
 
 
 class TestPurlStore(TestBase):
@@ -57,11 +58,12 @@ class TestPurlStore(TestBase):
         self.assertEqual(cache_entries[0]["purl"].qualifiers["classifier"], "sources")
         self.assertEqual(cache_entries[1]["href"], entry2)
         self.assertEqual(cache_entries[1]["purl"].qualifiers["classifier"], "dist")
-        res = sut.get_by_version(purl1)
-        if res is None:
-            self.fail("Expected results to be not None")
-        else:
-            self.assertEqual(len(res), 2)
+        for p in (purl1, purl2):
+            res = sut.get_by_version(p)
+            if res is None:
+                self.fail("Expected results to be not None for", p)
+            else:
+                self.assertEqual(len(res), 2)
 
     def test_add_duplicate_qualifiers(self) -> None:
         sut = PurlStore()
@@ -80,3 +82,77 @@ class TestPurlStore(TestBase):
             self.fail("Expected results to be not None")
         else:
             self.assertEqual(len(res), 2)
+
+    def test_get_with_filter_qualifiers(self) -> None:
+        sut = PurlStore()
+
+        purl1 = packageurl.PackageURL.from_string("pkg:maven/test/test@1?classifier=sources")
+        entry1 = "https://sw360.org/api/releases/123"
+        sut.add(purl1, entry1)
+
+        entry1_duplicate = "https://sw360.org/api/releases/124"
+        sut.add(purl1, entry1_duplicate)
+
+        purl2 = packageurl.PackageURL.from_string("pkg:maven/test/test@1?classifier=dist&type=zip")
+        entry2 = "https://sw360.org/api/releases/456"
+        sut.add(purl2, entry2)
+
+        purl3 = packageurl.PackageURL.from_string("pkg:maven/test/test@1")
+        entry3 = "https://sw360.org/api/releases/789"
+        sut.add(purl3, entry3)
+
+        # For known qualifiers, we should get the full match(es)
+        entries = sut.get_by_version(purl1)
+        result, entries = sut.filter_by_qualifiers(entries, purl1)
+        self.assertEqual(len(entries), 2)
+        hrefs = {entry["href"]: entry for entry in entries}
+        self.assertIn(entry1, hrefs)
+        self.assertEqual(hrefs[entry1]["purl"].qualifiers["classifier"], "sources")
+        self.assertIn(entry1_duplicate, hrefs)
+        self.assertEqual(hrefs[entry1_duplicate]["purl"].qualifiers["classifier"], "sources")
+        assert result == MapResultByIdQualifiers.FULL_MATCH
+
+        entries = sut.get_by_version(purl2)
+        result, entries = sut.filter_by_qualifiers(entries, purl2)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["href"], entry2)
+        self.assertEqual(entries[0]["purl"].qualifiers["classifier"], "dist")
+        assert result == MapResultByIdQualifiers.FULL_MATCH
+
+        # For the same version without qualifiers, we should get all entries
+        entries = sut.get_by_version(purl3)
+        result, entries = sut.filter_by_qualifiers(entries, purl3)
+        self.assertEqual(len(entries), 4)
+        hrefs = {entry["href"]: entry for entry in entries}
+        self.assertIn(entry1, hrefs)
+        self.assertEqual(hrefs[entry1]["purl"].qualifiers["classifier"], "sources")
+        self.assertIn(entry2, hrefs)
+        self.assertEqual(hrefs[entry2]["purl"].qualifiers["classifier"], "dist")
+        self.assertIn(entry3, hrefs)
+        self.assertEqual(hrefs[entry3]["purl"].qualifiers, {})
+        self.assertIn(entry1_duplicate, hrefs)
+        self.assertEqual(hrefs[entry1_duplicate]["purl"].qualifiers["classifier"], "sources")
+        assert result == MapResultByIdQualifiers.NO_QUALIFIER_MAPPING
+
+        # If all given qualifiers match, we should get the full match
+        purl4 = packageurl.PackageURL.from_string("pkg:maven/test/test@1?classifier=dist")
+        entries = sut.get_by_version(purl4)
+        result, entries = sut.filter_by_qualifiers(entries, purl4)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["href"], entry2)
+        self.assertEqual(entries[0]["purl"].qualifiers["classifier"], "dist")
+        assert result == MapResultByIdQualifiers.FULL_MATCH
+
+        # For the same version with an unknown qualifier, we should get all entries
+        purl4 = packageurl.PackageURL.from_string("pkg:maven/test/test@1?classifier=x86")
+        entries = sut.get_by_version(purl4)
+        result, entries = sut.filter_by_qualifiers(entries, purl4)
+        self.assertEqual(len(entries), 4)
+        assert result == MapResultByIdQualifiers.IGNORED
+
+        # Same if not all qualifiers match
+        purl5 = packageurl.PackageURL.from_string("pkg:maven/test/test@1?classifier=dist&type=jar")
+        entries = sut.get_by_version(purl5)
+        result, entries = sut.filter_by_qualifiers(entries, purl5)
+        self.assertEqual(len(entries), 4)
+        assert result == MapResultByIdQualifiers.IGNORED

--- a/tests/test_purl_utils.py
+++ b/tests/test_purl_utils.py
@@ -102,3 +102,9 @@ class TestPurlUtils(unittest.TestCase):
         input_purl = PackageURL.from_string("pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.1?type=jar")
         search_purl = PackageURL.from_string("pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.1")
         self.assertTrue(PurlUtils.contains([input_purl], search_purl))
+        # we are only comparing qualifiers existing in search_purl
+        self.assertTrue(PurlUtils.contains([input_purl], search_purl, compare_qualifiers=True))
+
+        search_purl = PackageURL.from_string("pkg:maven/org.springframework.boot/spring-boot-actuator@2.7.1?type=dist")
+        self.assertTrue(PurlUtils.contains([input_purl], search_purl))
+        self.assertFalse(PurlUtils.contains([input_purl], search_purl, compare_qualifiers=True))


### PR DESCRIPTION
Contains following changes/features:

* always search through all releases and include all best matches, don't abort on first good match -> implements #150
* return multiple releases with matching PURL -> implements #139
* consider PURL qualifiers during mapping if there's a full qualifier match -> implements #139

Fixes #139 
Fixes #150