### PR TITLE
Fix #118 mixed name and full matches

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
 * improvements in pulling package-urls from SW360.
 * pyjwt update to >= 2.4.0 due to CVE-2022-29217.
 * CaPyCLI now supports color console output also when running in GitLab CI.
+* `bom map` fix: In few cases with --nocache, it added mixed matches to output
+  BOM, now we assure that only the best mapping results are added.
 
 ## 2.7.0
 

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -126,30 +126,33 @@ class MapBom(capycli.common.script_base.ScriptBase):
         return False
 
     def add_match_if_better(self, map_result: MapResult, release: Dict[str, Any], proposed_match_code: str) -> bool:
-        if not map_result.releases:
-            is_better_match = True
+        """adds `release` with `proposed_match_code` to `map_result` if it is as good or better than the existing ones.
 
+        :return: True if the match was added, False if it was ignored
+        :rtype: bool
+        """
         best_match = MapResult.NO_MATCH
         for rel in map_result.releases:
             if rel["MapResult"] < best_match:
                 best_match = rel["MapResult"]
 
-        if best_match > proposed_match_code:
-            is_better_match = True
-        else:
-            is_better_match = False
+        if proposed_match_code > best_match:
+            if self.verbosity > 1:
+                print("    IGNORE (" + proposed_match_code + ")")
+            return False
 
-        if is_better_match:
+        if proposed_match_code < best_match and map_result.releases:
             map_result.releases.clear()
             if self.verbosity > 1:
                 print("    CLEAR (" + proposed_match_code + ")")
-            map_result.result = proposed_match_code
+
+        map_result.result = proposed_match_code
 
         release["MapResult"] = proposed_match_code
         map_result.releases.append(release)
         if self.verbosity > 1:
             print("    ADDED (" + proposed_match_code + ") " + release["Sw360Id"])
-        return is_better_match
+        return True
 
     @staticmethod
     def is_good_match(match_code: str) -> bool:

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -719,8 +719,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 2 total purls" in out)
         self.assertTrue("Found component 678dstzd8 via purl" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_ID)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_ID) 3765276512" in out)
+        self.assertTrue("CLEAR (1-full-match-by-id)" in out)
+        self.assertTrue("ADDED (1-full-match-by-id) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -933,8 +933,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 2 total purls" in out)
         self.assertTrue("Found component 678dstzd8 via purl" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_ID)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_ID) 3765276512" in out)
+        self.assertTrue("CLEAR (1-full-match-by-id)" in out)
+        self.assertTrue("ADDED (1-full-match-by-id) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -1315,8 +1315,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_NAME_AND_VERSION)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_NAME_AND_VERSION) 3765276512" in out)
+        self.assertTrue("CLEAR (3-full-match-by-name-and-version)" in out)
+        self.assertTrue("ADDED (3-full-match-by-name-and-version) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -1403,8 +1403,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_HASH)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_HASH) 3765276512" in out)
+        self.assertTrue("CLEAR (2-full-match-by-hash)" in out)
+        self.assertTrue("ADDED (2-full-match-by-hash) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -1491,8 +1491,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_HASH)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_HASH) 3765276512" in out)
+        self.assertTrue("CLEAR (2-full-match-by-hash)" in out)
+        self.assertTrue("ADDED (2-full-match-by-hash) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -1984,8 +1984,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_NAME_AND_VERSION)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_NAME_AND_VERSION) 3765276512" in out)
+        self.assertTrue("CLEAR (3-full-match-by-name-and-version)" in out)
+        self.assertTrue("ADDED (3-full-match-by-name-and-version) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -2133,8 +2133,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_HASH)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_HASH) 3765276512" in out)
+        self.assertTrue("CLEAR (2-full-match-by-hash)" in out)
+        self.assertTrue("ADDED (2-full-match-by-hash) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -2282,8 +2282,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (FULL_MATCH_BY_HASH)" in out)
-        self.assertTrue("ADDED (FULL_MATCH_BY_HASH) 3765276512" in out)
+        self.assertTrue("CLEAR (2-full-match-by-hash)" in out)
+        self.assertTrue("ADDED (2-full-match-by-hash) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -2431,8 +2431,8 @@ class CapycliTestBomMap(CapycliTestBase):
         self.assertTrue("1 component read from SBOM" in out)
         self.assertTrue("Retrieving package-url ids, filter: {'pypi'}" in out)
         self.assertTrue("Found 0 total purls" in out)
-        self.assertTrue("CLEAR (MATCH_BY_FILENAME)" in out)
-        self.assertTrue("ADDED (MATCH_BY_FILENAME) 3765276512" in out)
+        self.assertTrue("CLEAR (4-good-match-by-filename)" in out)
+        self.assertTrue("ADDED (4-good-match-by-filename) 3765276512" in out)
         self.assertTrue("Full matches    = 1" in out)
 
         # check result files
@@ -2707,67 +2707,63 @@ class CapycliTestBomMap(CapycliTestBase):
             if updated.purl:
                 self.assertEqual("pkg:pypi/a@2.0", updated.purl.to_string())
 
-    def test_is_better_match(self) -> None:
+    def test_add_match_if_better(self) -> None:
         sut = MapBom()
 
+        release = {}
+
         # empty release list
-        val = sut.is_better_match([], MapResult.MATCH_BY_FILENAME)
-        self.assertTrue(val)
-
-        val = sut.is_better_match([], MapResult.MATCH_BY_FILENAME)
-        self.assertTrue(val)
-
-        release = {}
+        result = MapResult()
         release["MapResult"] = MapResult.NO_MATCH
+        val = sut.add_match_if_better(result, release, MapResult.MATCH_BY_FILENAME)
+        assert len(result.releases) == 1
+        self.assertTrue(val)
 
-        val = sut.is_better_match([release], MapResult.NO_MATCH)
+        result = MapResult()
+        release["MapResult"] = MapResult.NO_MATCH
+        result.releases = [release]
+        val = sut.add_match_if_better(result, release, MapResult.NO_MATCH)
         self.assertFalse(val)
 
-        val = sut.is_better_match([release], MapResult.SIMILAR_COMPONENT_FOUND)
+        result = MapResult()
+        release["MapResult"] = MapResult.NO_MATCH
+        result.releases = [release]
+        val = sut.add_match_if_better(result, release, MapResult.SIMILAR_COMPONENT_FOUND)
         self.assertTrue(val)
 
-        releases_found = []
-        release = {}
-        release["MapResult"] = MapResult.NO_MATCH
-        releases_found.append(release)
-
-        release = {}
+        result = MapResult()
         release["MapResult"] = MapResult.SIMILAR_COMPONENT_FOUND
-        releases_found.append(release)
-
-        val = sut.is_better_match(releases_found, MapResult.SIMILAR_COMPONENT_FOUND)
+        result.releases = [release]
+        val = sut.add_match_if_better(result, release, MapResult.SIMILAR_COMPONENT_FOUND)
         self.assertFalse(val)
 
-        val = sut.is_better_match(releases_found, MapResult.MATCH_BY_NAME)
+        val = sut.add_match_if_better(result, release, MapResult.MATCH_BY_NAME)
         self.assertTrue(val)
 
         release = {}
         release["MapResult"] = MapResult.MATCH_BY_NAME
-        releases_found.append(release)
-
+        result.releases.append(release)
         release = {}
         release["MapResult"] = MapResult.MATCH_BY_FILENAME
-        releases_found.append(release)
-
+        result.releases.append(release)
         release = {}
         release["MapResult"] = MapResult.FULL_MATCH_BY_NAME_AND_VERSION
-        releases_found.append(release)
-
+        result.releases.append(release)
         release = {}
         release["MapResult"] = MapResult.FULL_MATCH_BY_HASH
-        releases_found.append(release)
+        result.releases.append(release)
 
-        val = sut.is_better_match(releases_found, MapResult.FULL_MATCH_BY_HASH)
+        val = sut.add_match_if_better(result, release, MapResult.FULL_MATCH_BY_HASH)
         self.assertFalse(val)
 
-        val = sut.is_better_match(releases_found, MapResult.FULL_MATCH_BY_ID)
+        val = sut.add_match_if_better(result, release, MapResult.FULL_MATCH_BY_ID)
         self.assertTrue(val)
 
         release = {}
         release["MapResult"] = MapResult.FULL_MATCH_BY_ID
-        releases_found.append(release)
+        result.releases.append(release)
 
-        val = sut.is_better_match(releases_found, MapResult.FULL_MATCH_BY_HASH)
+        val = sut.add_match_if_better(result, release, MapResult.FULL_MATCH_BY_HASH)
         self.assertFalse(val)
 
     def test_is_good_match(self) -> None:


### PR DESCRIPTION
As described in #118, this fixes rare cases where `bom map` added good and worse matches to the output BOM for --nocache mode.

This first adds test cases for some missing cases to reduce the risk we break things on refactoring, then moves the existing code to a central method and finally improves the match handling there.