### PR TITLE
Fix/mapping with duplicate purls

### DIFF
--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -322,16 +322,6 @@ class MapBom(capycli.common.script_base.ScriptBase):
                     continue
 
                 # generate proper release for result
-                release = {}
-                release["Name"] = real_release["name"]
-                if self.relaxed_debian_parsing:
-                    release["Version"] = self.cut_off_debian_extras(real_release["version"])
-                else:
-                    release["Version"] = real_release["version"]
-                release["ExternalIds"] = real_release.get("externalIds", "")
-                release["Id"] = release["Sw360Id"] = self.client.get_id_from_href(href)
-                release["ComponentId"] = self.client.get_id_from_href(compref)
-
                 release = ComponentCacheManagement.convert_release_details(self.client, real_release)
 
                 # first check: unique id
@@ -643,11 +633,6 @@ class MapBom(capycli.common.script_base.ScriptBase):
                         newitem,
                         CycloneDxSupport.CDX_PROP_MAPRESULT,
                         MapResult.NO_MATCH)
-                    if item.component_id is not None:
-                        CycloneDxSupport.update_or_set_property(
-                            newitem,
-                            CycloneDxSupport.CDX_PROP_COMPONENT_ID,
-                            item.component_id)
                 newbom.components.add(newitem)
 
             # Sorted alternatives in descending version order

--- a/capycli/common/map_result.py
+++ b/capycli/common/map_result.py
@@ -48,27 +48,29 @@ class MapResult:
     def __init__(self, component: Optional[Component] = None) -> None:
         self.input_component: Optional[Component] = component
         self.result: str = MapResult.NO_MATCH
-        self._component_id: str = ""
-        self._release_id: str = ""
+        self._component_href: str = ""
+        self._release_href: str = ""
         self.releases: List[Any] = []
 
     @property
-    def component_id(self) -> str:
-        return self._component_id
+    def component_href(self) -> str:
+        return self._component_href
 
-    @component_id.setter
-    def component_id(self, value: str) -> None:
-        self._component_id = value
+    @component_href.setter
+    def component_href(self, value: str) -> None:
+        self._component_href = value
+        value = value.split("/")[-1]
         if self.input_component:
             CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_COMPONENT_ID, value)
 
     @property
-    def release_id(self) -> str:
-        return self._release_id
+    def release_href(self) -> str:
+        return self._release_href
 
-    @release_id.setter
-    def release_id(self, value: str) -> None:
-        self._release_id = value
+    @release_href.setter
+    def release_href(self, value: str) -> None:
+        self._release_href = value
+        value = value.split("/")[-1]
         if self.input_component:
             CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_SW360ID, value)
 

--- a/capycli/common/map_result.py
+++ b/capycli/common/map_result.py
@@ -48,31 +48,40 @@ class MapResult:
     def __init__(self, component: Optional[Component] = None) -> None:
         self.input_component: Optional[Component] = component
         self.result: str = MapResult.NO_MATCH
-        self._component_href: str = ""
-        self._release_href: str = ""
+        self._component_hrefs: List[str] = []
+        self._release_hrefs: List[str] = []
         self.releases: List[Any] = []
 
     @property
-    def component_href(self) -> str:
-        return self._component_href
+    def component_hrefs(self) -> List[str]:
+        return self._component_hrefs
 
-    @component_href.setter
-    def component_href(self, value: str) -> None:
-        self._component_href = value
-        value = value.split("/")[-1]
-        if self.input_component:
-            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_COMPONENT_ID, value)
+    @component_hrefs.setter
+    def component_hrefs(self, value: List[str]) -> None:
+        self._component_hrefs = value
+        if not self.input_component:
+            return
+        if len(value) == 1:
+            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_COMPONENT_ID,
+                                                    value[0].split("/")[-1])
+        else:
+            CycloneDxSupport.remove_property(self.input_component,
+                                             CycloneDxSupport.CDX_PROP_COMPONENT_ID)
 
     @property
-    def release_href(self) -> str:
-        return self._release_href
+    def release_hrefs(self) -> List[str]:
+        return self._release_hrefs
 
-    @release_href.setter
-    def release_href(self, value: str) -> None:
-        self._release_href = value
-        value = value.split("/")[-1]
-        if self.input_component:
-            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_SW360ID, value)
+    @release_hrefs.setter
+    def release_hrefs(self, value: List[str]) -> None:
+        self._release_hrefs = value
+        if not self.input_component:
+            return
+        if len(value) == 1:
+            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_SW360ID,
+                                                    value[0].split("/")[-1])
+        else:
+            CycloneDxSupport.remove_property(self.input_component, CycloneDxSupport.CDX_PROP_SW360ID)
 
     @classmethod
     def map_code_to_string(cls, map_code: str) -> str:

--- a/capycli/common/map_result.py
+++ b/capycli/common/map_result.py
@@ -46,7 +46,7 @@ class MapResult:
     NO_MATCH = "9-no-match"
 
     def __init__(self, component: Optional[Component] = None) -> None:
-        self.component: Optional[Component] = component
+        self.input_component: Optional[Component] = component
         self.result: str = MapResult.NO_MATCH
         self._component_id: str = ""
         self._release_id: str = ""
@@ -59,8 +59,8 @@ class MapResult:
     @component_id.setter
     def component_id(self, value: str) -> None:
         self._component_id = value
-        if self.component:
-            CycloneDxSupport.update_or_set_property(self.component, CycloneDxSupport.CDX_PROP_COMPONENT_ID, value)
+        if self.input_component:
+            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_COMPONENT_ID, value)
 
     @property
     def release_id(self) -> str:
@@ -69,8 +69,8 @@ class MapResult:
     @release_id.setter
     def release_id(self, value: str) -> None:
         self._release_id = value
-        if self.component:
-            CycloneDxSupport.update_or_set_property(self.component, CycloneDxSupport.CDX_PROP_SW360ID, value)
+        if self.input_component:
+            CycloneDxSupport.update_or_set_property(self.input_component, CycloneDxSupport.CDX_PROP_SW360ID, value)
 
     @classmethod
     def map_code_to_string(cls, map_code: str) -> str:
@@ -109,7 +109,7 @@ class MapResult:
                 + more
             )
 
-        if not self.component:
+        if not self.input_component:
             return (
                 self.map_code_to_string(self.result)
                 + ", (no component), "
@@ -119,9 +119,9 @@ class MapResult:
             return (
                 self.map_code_to_string(self.result)
                 + ", "
-                + str(self.component.name)
+                + str(self.input_component.name)
                 + ", "
-                + str(self.component.version or "")
+                + str(self.input_component.version or "")
                 + " "
                 + str(rel)
             )

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -458,7 +458,7 @@ class CapycliTestBomMap(CapycliTestBase):
     @responses.activate
     def test_create_updated_bom_component_id(self) -> None:
         res = MapResult()
-        res.component = Component(name="sed", version="1.1")
+        res.input_component = Component(name="sed", version="1.1")
         res.result = MapResult.MATCH_BY_NAME
         res.component_id = "a035"
         res.releases = [{'Name': 'sed', 'Version': '1.0',
@@ -494,7 +494,7 @@ class CapycliTestBomMap(CapycliTestBase):
     @responses.activate
     def test_create_updated_bom_mixed_match(self) -> None:
         res = MapResult()
-        res.component = Component(name="mail", version="1.4")
+        res.input_component = Component(name="mail", version="1.4")
         res.result = MapResult.FULL_MATCH_BY_NAME_AND_VERSION
         res.releases = [
             {'Name': 'mail', 'Version': '1.4',

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -67,7 +67,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item(bomitem, check_similar=False, result_required=False)
         assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["Sw360Id"] == "1234"
         assert res.releases[0]["ComponentId"] == "a035"
 
@@ -78,14 +78,14 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item(bomitem, check_similar=False, result_required=False)
         assert res.result == MapResult.NO_MATCH
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert len(res.releases) == 0
 
         # enable name matching
         self.app.no_match_by_name_only = False
         res = self.app.map_bom_item(bomitem, check_similar=False, result_required=False)
         assert res.result == MapResult.MATCH_BY_NAME
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["ComponentId"] == "a035"
         assert len(res.releases) == 1
 
@@ -116,7 +116,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item(bomitem, check_similar=False, result_required=False)
         assert res.result == MapResult.FULL_MATCH_BY_ID
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["Sw360Id"] == "1234"
         assert res.releases[0]["ComponentId"] == "a035"
 
@@ -360,7 +360,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["Sw360Id"] == "1234"
         assert res.releases[0]["ComponentId"] == "a035"
 
@@ -370,14 +370,14 @@ class CapycliTestBomMap(CapycliTestBase):
             purl=PackageURL.from_string("pkg:deb/debian/sed@1.1?type=source"))
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.NO_MATCH
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert len(res.releases) == 0
 
         # enable name matching
         self.app.no_match_by_name_only = False
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.MATCH_BY_NAME
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["ComponentId"] == "a035"
         assert len(res.releases) == 1
 
@@ -416,7 +416,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.FULL_MATCH_BY_NAME_AND_VERSION
-        assert res.component_id == ""
+        assert res.component_href == ""
         assert res.releases[0]["Sw360Id"] == "1235"
         assert res.releases[0]["ComponentId"] == "a034"
 
@@ -449,7 +449,7 @@ class CapycliTestBomMap(CapycliTestBase):
 
         res = self.app.map_bom_item_no_cache(bomitem)
         assert res.result == MapResult.FULL_MATCH_BY_ID
-        assert res.component_id == "a035"
+        assert res.component_href == SW360_BASE_URL + "components/a035"
         assert res.releases[0]["Sw360Id"] == "1234"
         assert res.releases[0]["ComponentId"] == "a035"
 
@@ -460,7 +460,7 @@ class CapycliTestBomMap(CapycliTestBase):
         res = MapResult()
         res.input_component = Component(name="sed", version="1.1")
         res.result = MapResult.MATCH_BY_NAME
-        res.component_id = "a035"
+        res.component_href = SW360_BASE_URL + "components/a035"
         res.releases = [{'Name': 'sed', 'Version': '1.0',
                          'Id': '1234', 'MapResult': MapResult.MATCH_BY_NAME}]
         oldbom = Bom()
@@ -483,7 +483,7 @@ class CapycliTestBomMap(CapycliTestBase):
         assert prop == "a035"
 
         res.result = MapResult.NO_MATCH
-        res.component_id = "a035"
+        res.component_href = SW360_BASE_URL + "components/a035"
         res.releases = []
         newbom = self.app.create_updated_bom(oldbom, [res])
         prop = CycloneDxSupport.get_property_value(newbom.components[0], CycloneDxSupport.CDX_PROP_MAPRESULT)


### PR DESCRIPTION
This fixes #123 as discussed, returning one random result identified by PURL even if there are duplicated PURLs in SW360. 

Note that the first three commits are not directly related, just suggestions for refactorings/simplifications I identified when working with the existing code. Please let me know if you don't agree with some of them, then we can alter or remove!
