### PR TITLE
Revert breaking change (reset of project_info)

### DIFF
--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -95,7 +95,6 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             if project_info and element in project_info:
                 project_info.pop(element)
 
-        project_info: Dict[str, Any] = {}
         if project:
             project_info["additionalData"] = project.get("additionalData", {})
             if "createdWith" not in project.get("additionalData", {}):


### PR DESCRIPTION
Resetting the "project_info" has an undesired side-effect: doesn't allow the patch of the SW360 project for fields like (example): "linkedProjects", "moderators".
![image](https://github.com/user-attachments/assets/66c3216d-709f-459c-89a9-a278b575a025)
