### PR TITLE
fix(pyproject.toml): fix spelling of license file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["sw360", "cli, automation", "license", "compliance", "clearing"]
 license-files = [
-    "LICENSE.md"
+    "License.md"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -54,7 +54,7 @@ capycli = "capycli.main.cli:main"
 
 [tool.poetry]
 include = [
-    "LICENSE.md",
+    "License.md",
     { path = "capycli/data/granularity_list.csv", format = "wheel" },
     { path = "capycli/data/__init__.py", format = "wheel" },
     { path = "capycli/data/granularity_list.csv", format = "sdist" },


### PR DESCRIPTION
It seems new pyproject.toml syntax is case sensitive and the real filename in Git is "License.md".

This fixes #173 on my Linux machine.