### PR TITLE
Fix SBOM Python packackage names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@
 * Adapt `getdependencies python` to the Poetry 2.x pyproject.toml format.
 * `getdependencies python` now also supports uv and its `uv.lock` file.
 * Have correct `file:///` uri for files in SBOM external references.
+* `getdependencies python` writes now correct package names **with dashed** in the SBOM.
 
 ## 2.9.1
 

--- a/capycli/dependencies/python.py
+++ b/capycli/dependencies/python.py
@@ -81,7 +81,7 @@ class GetPythonDependencies(capycli.common.script_base.ScriptBase):
         see https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
         """
         _NORMALIZE_MATCHER = compile(r"[-_.]+")
-        return _NORMALIZE_MATCHER.sub("_", name.lower())
+        return _NORMALIZE_MATCHER.sub("-", name.lower())
 
     def requirements_to_package_list(self, input_file: str) -> List[Dict[str, str]]:
         """

--- a/tests/test_get_dependencies_python.py
+++ b/tests/test_get_dependencies_python.py
@@ -411,7 +411,7 @@ class TestGetDependenciesPython(TestBase):
         out = self.capture_stdout(sut.run, args)
         # self.dump_textfile(out, "DUMP.TXT")
         self.assertTrue("Checking meta-data:" in out)
-        self.assertTrue("cli_support" in out)
+        self.assertTrue("cli-support" in out)
         self.assertTrue(self.OUTPUTFILE2 in out)
         self.assertTrue("30 components items written to file." in out)
 
@@ -444,7 +444,7 @@ class TestGetDependenciesPython(TestBase):
         out = self.capture_stdout(sut.run, args)
         # self.dump_textfile(out, "DUMP.TXT")
         self.assertTrue("Checking meta-data:" in out)
-        self.assertTrue("cli_support" in out)
+        self.assertTrue("cli-support" in out)
         self.assertTrue(self.OUTPUTFILE2 in out)
         # for the real version 2.6.0 source code it would be 39 components,
         # but for the test the umber is different
@@ -479,7 +479,7 @@ class TestGetDependenciesPython(TestBase):
         out = self.capture_stdout(sut.run, args)
         # self.dump_textfile(out, "DUMP.TXT")
         self.assertTrue("Checking meta-data:" in out)
-        self.assertTrue("cli_support, 2.0.1" in out)
+        self.assertTrue("cli-support, 2.0.1" in out)
         self.assertTrue(self.OUTPUTFILE2 in out)
         # for the real version 2.6.0 source code it would be 39 components,
         # but for the test the number is different
@@ -514,7 +514,7 @@ class TestGetDependenciesPython(TestBase):
         out = self.capture_stdout(sut.run, args)
         # self.dump_textfile(out, "DUMP.TXT")
         self.assertTrue("Checking meta-data:" in out)
-        self.assertTrue("cli_support, 2.0.1" in out)
+        self.assertTrue("cli-support, 2.0.1" in out)
         self.assertTrue(self.OUTPUTFILE2 in out)
         self.assertTrue(" components items written to file." in out)
 


### PR DESCRIPTION
`getdependencies python` writes now correct package names **with dashed** in the SBOM.