### PR TITLE
CaPyCLI displays a warning when the source file does not look ...

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,8 @@
 * `getdependencies python` writes now correct package names **with dashed** in the SBOM.
 * `getdependencies python` now first tries to get `GitHub` source code urls, before
   using `pythonhosted` urls.
+* CaPyCLI displays a warning in `bom show`, `bom DownloadSources`, or `bom CreateReleases`
+  when the source file does not look like a source file, i.e. the file extension does not match.
 
 ## 2.9.1
 

--- a/capycli/bom/create_components.py
+++ b/capycli/bom/create_components.py
@@ -24,6 +24,7 @@ from sw360 import SW360Error
 
 import capycli.common.json_support
 import capycli.common.script_base
+from capycli.bom.download_sources import BomDownloadSources
 from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport, SbomWriter
 from capycli.common.print import print_green, print_red, print_text, print_yellow
 from capycli.common.purl_utils import PurlUtils
@@ -162,6 +163,8 @@ class BomCreateComponents(capycli.common.script_base.ScriptBase):
                             "      File with the name '", tail, "' is already attached to release. Skip the upload!")
                     else:
                         self.upload_source_file(release_id, fullpath, filetype, comment)
+                        if not BomDownloadSources.is_good_source_file(fullpath):
+                            print_yellow("    Downloaded file seems not to be a valid source file!")
                 except Exception as ex:
                     print_red("      Error writing downloaded file: " + repr(ex))
             else:

--- a/capycli/bom/download_sources.py
+++ b/capycli/bom/download_sources.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2020-2023 Siemens
+# Copyright (c) 2020-2025 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -45,6 +45,16 @@ class BomDownloadSources(capycli.common.script_base.ScriptBase):
             return ""
         return fname[0].rstrip('"').lstrip('"')
 
+    @staticmethod
+    def is_good_source_file(filename: str) -> bool:
+        """
+        Checks whether this seems to be a valid/good source file.
+        The only thing we can do it to check the file extension.
+        """
+        good_extensions = [".zip", ".tar", ".gz", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz", ".7z"]
+        _, extension = os.path.splitext(filename)
+        return extension in good_extensions
+
     def download_source_file(self, url: str, source_folder: str) -> Optional[Tuple[str, str]]:
         """Download a file from a URL.
 
@@ -70,6 +80,8 @@ class BomDownloadSources(capycli.common.script_base.ScriptBase):
             path = os.path.join(source_folder, filename)
             if (response.status_code == requests.codes["ok"]):
                 open(path, "wb").write(response.content)
+                if not BomDownloadSources.is_good_source_file(path):
+                    print_yellow("    Downloaded file seems not to be a valid source file!")
                 sha1 = hashlib.sha1(response.content).hexdigest()
                 return (path, sha1)
             else:

--- a/capycli/bom/show_bom.py
+++ b/capycli/bom/show_bom.py
@@ -20,6 +20,7 @@ from cyclonedx.model.component import Component
 from cyclonedx.model.license import DisjunctiveLicense, LicenseExpression
 
 import capycli.common.script_base
+from capycli.bom.download_sources import BomDownloadSources
 from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport
 from capycli.common.print import print_red, print_text, print_yellow
 from capycli.main.result_codes import ResultCode
@@ -84,6 +85,9 @@ class ShowBom(capycli.common.script_base.ScriptBase):
                 download_url = CycloneDxSupport.get_ext_ref_source_url(bomitem)
                 if download_url:
                     print_text("    download URL: " + download_url.uri)
+                    if not BomDownloadSources.is_good_source_file(download_url.uri):
+                        print_yellow("    Download file seems not to be a valid source file!")
+                        self.has_error = True
                 else:
                     print_yellow("    No download URL given!")
                     self.has_error = True

--- a/tests/test_bom_downloadsources.py
+++ b/tests/test_bom_downloadsources.py
@@ -287,6 +287,16 @@ class TestBomDownloadsources(TestBase):
 
         self.assertTrue(False, "Error: we must never arrive here")
 
+    def test_is_good_source_file(self) -> None:
+        sut = BomDownloadSources()
+        self.assertTrue(sut.is_good_source_file("good_file.tar.gz"))
+        self.assertTrue(sut.is_good_source_file("good_file.tgz"))
+        self.assertTrue(sut.is_good_source_file("good_file.zip"))
+        self.assertTrue(sut.is_good_source_file("good_file.7z"))
+        self.assertFalse(sut.is_good_source_file("bad_file.html"))
+        self.assertFalse(sut.is_good_source_file("https://someurl.com/"))
+        self.assertFalse(sut.is_good_source_file("nonexistentfile.xyz"))
+
 
 if __name__ == "__main__":
     lib = TestBomDownloadsources()


### PR DESCRIPTION
CaPyCLI displays a warning in `bom show`, `bom DownloadSources`, or `bom CreateReleases`
when the source file does not look like a source file, i.e. the file extension does not match.