### PR TITLE
fix: bug in `bom filter`, that happened in verbose output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@
 * Improve dependency detection in `getdependencies javascript`.
 * Fix issue in `project prerequisites` when reading an empty project.
 
+## NEXT
+
+* Fixed a bug in `bom filter`, that happened in verbose output when using a purl for filtering.
+
 ## 2.10.0
 
 * Have `bom bompackage` as a separate command and have the advanced folder structure

--- a/capycli/bom/filter_bom.py
+++ b/capycli/bom/filter_bom.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2019-2024 Siemens
+# Copyright (c) 2019-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -251,10 +251,16 @@ class FilterBom(capycli.common.script_base.ScriptBase):
         if self.verbose:
             for filterentry in filter["Components"]:
                 if not filterentry["Processed"]:
-                    print_yellow(
-                        "  No matching entry found for " +
-                        filterentry["component"]["Name"] + ", " +
-                        filterentry["component"].get("Version", "(all)"))
+                    searchitem = ""
+                    if filterentry["component"].get("Name"):
+                        searchitem = filterentry["component"]["Name"] + ", "\
+                            + filterentry["component"].get("Version", "(all)")
+                    elif filterentry["component"].get("RepositoryId"):
+                        searchitem = filterentry["component"]["RepositoryId"]
+
+                    if searchitem:
+                        print_yellow(
+                            "  No matching entry found for " + searchitem)
 
             print()
 


### PR DESCRIPTION
Fixed a bug in `bom filter`, that happened in verbose output when using a purl for filtering.