### PR TITLE
fix(Readme_Workflow): adapt to new "bom convert" syntax

### DIFF
--- a/Readme_Workflow.md
+++ b/Readme_Workflow.md
@@ -42,9 +42,8 @@ CaPyCLI offers some basic support to do this
 * `CaPyCLI getdependencies MavenPom`
 * `CaPyCLI getdependencies MavenList`
 
-You can also convert a flat list of component names and version to a SBOM using the
-`CaPyCLI bom FromFlatList` command. It is also possible to convert a CSV file to a SBOM using the
-`CaPyCLI bom FromCSV` command.
+You can also convert a flat list of component names and versions or a CSV file to an SBOM using the
+`CaPyCLI bom Convert` command.
 
 Again, this is only very basic support. For better results we recommend the tools provided by [CycloneDX](https://cyclonedx.org/):
 


### PR DESCRIPTION
In [release 2.0](https://github.com/sw360/capycli/releases/tag/v2.0.0), the "bom from*" commands were replaced by "bom convert". Thanks to https://github.com/rfuentess for reporting that Readme_Workflow.md still uses the old names.

Fixes #209