### PR TITLE
chore: switch to poetry-core backend

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -24,7 +24,7 @@ Files:  tests/fixtures/*
 Copyright: 2018-2023 Siemens
 License: MIT
 
-Files: capycli/data/granularity_list.csv requirements.txt capycli/data/component_checks.json
+Files: capycli/data/granularity_list.csv capycli/data/component_checks.json
 Copyright: 2018-2026 Siemens
 License: MIT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,8 @@ pyinstaller = "^6.17.0"
 flake8 = "^7.3.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
Replace legacy `poetry.masonry.api` with `poetry.core.masonry.api`. The old backend lacks `build_editable()` (PEP 660 [1]), breaking editable installs with standards-compliant installers like uv or pip >= 21.3. For example, this allows developers to use uv instead of poetry for local development.

poetry-core is Poetry's officially recommended build backend [2]. It is lighter (no resolver/CLI/plugins pulled in at build time) and supports the full PEP 517/660 interface.

Also, remove empty requirements.txt as it is no longer in use since commit 7334e7a109eec94525535a37b88821e946509421, so let's just remove it to avoid any confusion.

[1] https://peps.python.org/pep-0660/
[2] https://python-poetry.org/docs/basic-usage/