### PR TITLE
feat: update SBOM external reference type for source code URLs from `…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,8 @@
 * update dependencies, especially "idna" to fix CVE-2026-45409 and "sw360" lib
   to fix CVE-2026-41066,  CVE-2026-44431 and CVE-2026-44432. When accessing a
   trusted SW360 server using REST API, they all shouldn't be critical, however.
+* Update SBOM external reference type for source code URLs from `distribution`
+  to `source-distribution`.
 
 ## 2.11.1
 

--- a/SBOM/sbom_no_dev_old.cyclonedx.json
+++ b/SBOM/sbom_no_dev_old.cyclonedx.json
@@ -1,0 +1,11703 @@
+{
+  "components": [
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/attrs@26.1.0",
+      "copyright": "N/A",
+      "description": "Classes Without Boilerplate",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///attrs-26.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///attrs-26.1.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python-attrs/attrs/archive/tags/26.1.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/attrs/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python-attrs/attrs"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "attrs",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/attrs@26.1.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "26.1.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/beautifulsoup4@4.14.3",
+      "copyright": "N/A",
+      "description": "Screen-scraping library",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///beautifulsoup4-4.14.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///beautifulsoup4-4.14.3.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/beautifulsoup4/"
+        },
+        {
+          "type": "website",
+          "url": "https://www.crummy.com/software/BeautifulSoup/bs4/"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT License"
+          }
+        }
+      ],
+      "name": "beautifulsoup4",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.14.3",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "4.14.3"
+    },
+    {
+      "author": "Sebastian Kraemer",
+      "bom-ref": "pkg:pypi/boolean-py@5.0",
+      "copyright": "N/A",
+      "description": "Define boolean algebras, create and parse boolean expressions and create custom boolean DSL.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///boolean_py-5.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///boolean_py-5.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/bastikr/boolean.py/archive/tags/v5.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/boolean.py/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bastikr/boolean.py"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "boolean-py",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/boolean-py@5.0",
+      "supplier": {
+        "name": "Sebastian Kraemer"
+      },
+      "type": "library",
+      "version": "5.0"
+    },
+    {
+      "author": "Kenneth Reitz",
+      "bom-ref": "pkg:pypi/certifi@2026.2.25",
+      "copyright": "N/A",
+      "description": "Python package for providing Mozilla's CA Bundle.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///certifi-2026.2.25-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///certifi-2026.2.25.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/certifi/python-certifi/archive/refs/tags/2026.02.25.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/certifi/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/certifi/python-certifi"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MPL-2.0"
+          }
+        }
+      ],
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2026.2.25",
+      "supplier": {
+        "name": "Kenneth Reitz"
+      },
+      "type": "library",
+      "version": "2026.2.25"
+    },
+    {
+      "author": "Mark Pilgrim",
+      "bom-ref": "pkg:pypi/chardet@5.2.0",
+      "copyright": "N/A",
+      "description": "Universal encoding detector for Python 3",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///chardet-5.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///chardet-5.2.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/chardet/chardet/archive/tags/5.2.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/chardet/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/chardet/chardet"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "LGPL"
+          }
+        }
+      ],
+      "name": "chardet",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/chardet@5.2.0",
+      "supplier": {
+        "name": "Mark Pilgrim"
+      },
+      "type": "library",
+      "version": "5.2.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/charset-normalizer@3.4.7",
+      "copyright": "N/A",
+      "description": "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///charset_normalizer-3.4.7.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/01/1b/ef725f8eb19b5a261b30f78efa9252ef9d017985cb499102f6f49834cd12/charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/04/2a/c1f1f791467d865b48b749842c895668229e553dd79b71ad80498a0b646f/charset_normalizer-3.4.7-cp38-cp38-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0e/f1/40a59aae52edc5275e85813cbc49621c10758f481deeb27f71c97406cda0/charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/12/46/fce169ad09419b8e8a5a81db61e08cd7b9fd31332221b84bd176fe0a3136/charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/17/85/cacf6d45cff52be431468ee4cfa6f625eb622ab8f23a892218af8c77094d/charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1a/62/d9340c7a79c393e57807d7fb6c57e82060687891f81b74d3201958b919c1/charset_normalizer-3.4.7-cp39-cp39-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1a/64/3f9142293c88b1b10e199649ed1330f070c2a68e305335a5819fa7f25fa7/charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/ec/90339ff5cdc598b265748c1f231c7d7fbd9123a92cee10f757e0b1448de4/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/21/7b/c414866a138400b2e81973d006da7f694cfeaf895ef07d2cba9a8743841a/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/21/e7/92901117e2ddc8facfe8235a3ecd4eb482185b2ad5d5b6606b37c1afea06/charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2e/92/bdcf94997e06b223d826df3abed45a5ad6e17f609b7df9d25cd23b5bde30/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2e/e7/a7a6147f8e3375676309cf584b25c72a3bab784ea4085b0011fa07b23aeb/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/47/3f/9bb0864a92b4abf0ec0d1f40546297f45afd73851795e3216c899b360aa0/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/52/f9/47a52cbcce0140f612ef7a37797b2929244bcaaf2f83ade3775429457252/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6c/0e/0f722c41d983dd204b3142606fbfcdbb0a33c34b9b031ef3c1fe9e8187ad/charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6f/5e/9e74560659e3f8a7650e09dac978749d408917c8e9764af13f5f81ceec53/charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/75/20/8b3cefb78df39d40272d7831dda07b51875d89af1f390f97a801eaedec78/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/76/79/0e09d2169b7ba38a04e9660669d124ea688605f66189030e4c2be44d8e27/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/81/76/14ab25789e14f83124c4318f0edbbf15a6ed535bd3d88720c42001a954df/charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8f/9b/7c7f4b7f11525fcbdfba752455314ac60646bae91cdd671d531c1f7a97c6/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/96/53/6ea2906da0fd3773d57398e7cee5628d004d844b0c4903ea3038ae8488cd/charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9f/57/301682e7469bdbfa2ce219a804f0668b2266ab8520570d85d3b3ef483ea3/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a3/22/2f12878fbc680fbbb52386cd39a379801f62eaca74fc8b323381325f0f04/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bc/b6/10c84e789126ca97d4a7228863a30481e786980a8b8cfcbf4f30658ca63c/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c1/d1/d8a6b7dd5c5636b76ce0d080bc57d8e56c7bbd6bc2ac941529a35e41d84a/charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/cc/4f/e1fb138201ad9a32499dd9a98aa4a5a5441fbf7f56b52b619a54b7ee8777/charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d3/5e/8161a7bbf4a7f88d0409091ab5a5762c014913c9ef80a48b50f806140918/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d5/2a/41816ceda78a551cbfdfbeab6f3891152b0e3f758ce6580c2c18c829f774/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/dd/8c/60ebe912379627d023eb96995b40bc50308729f210f43d66109ca0a7bbd2/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ec/5e/0739d2975ae6fd42505fdb80881ab5e99b4edfbff1d581f4cd5aa94f2d94/charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ef/ec/e7961eea9977a4d5ac920627e78938784272cb9b752cf1209da91e93d006/charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/jawah/charset_normalizer/archive/tags/3.4.7.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/charset-normalizer/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/jawah/charset_normalizer"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.4.7",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "3.4.7"
+    },
+    {
+      "author": "Thomas Graf",
+      "bom-ref": "pkg:pypi/cli-support@2.0.1",
+      "copyright": "N/A",
+      "description": "Support component license information (CLI) files",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9f429b0169b61452fe9436f51a7ad7db2423aaeb44d8116d6695c8f1e04363d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///cli_support-2.0.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "19034558dc7c830eaeb15f18452e16568b431e14bc74b51233911412639aa724"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///cli_support-2.0.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f9f429b0169b61452fe9436f51a7ad7db2423aaeb44d8116d6695c8f1e04363d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/42/f5/7945f2e47772c8da721a0e382b3d8e9aa1ef22cd689603a3fed7c10fec5a/cli_support-2.0.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/sw360/clipython/archive/tags/v2.0.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/cli-support/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/sw360/clipython"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f9f429b0169b61452fe9436f51a7ad7db2423aaeb44d8116d6695c8f1e04363d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "cli-support",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/cli-support@2.0.1",
+      "supplier": {
+        "name": "Thomas Graf"
+      },
+      "type": "library",
+      "version": "2.0.1"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/colorama@0.4.6",
+      "copyright": "N/A",
+      "description": "Cross-platform colored terminal text.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///colorama-0.4.6.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/tartley/colorama/archive/tags/0.4.6.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/colorama/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/tartley/colorama"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "colorama",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/colorama@0.4.6",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "0.4.6"
+    },
+    {
+      "author": "Paul Horton",
+      "bom-ref": "pkg:pypi/cyclonedx-python-lib@11.7.0",
+      "copyright": "N/A",
+      "description": "Python library for CycloneDX",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///cyclonedx_python_lib-11.7.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///cyclonedx_python_lib-11.7.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/CycloneDX/cyclonedx-python-lib//archive/tags/v11.7.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/cyclonedx-python-lib/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "cyclonedx-python-lib",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/cyclonedx-python-lib@11.7.0",
+      "supplier": {
+        "name": "Paul Horton"
+      },
+      "type": "library",
+      "version": "11.7.0"
+    },
+    {
+      "author": "Scrapinghub",
+      "bom-ref": "pkg:pypi/dateparser@1.4.0",
+      "copyright": "N/A",
+      "description": "Date parsing library designed to parse dates from HTML pages",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///dateparser-1.4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///dateparser-1.4.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/scrapinghub/dateparser/archive/tags/v1.4.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/dateparser/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/scrapinghub/dateparser"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "name": "dateparser",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/dateparser@1.4.0",
+      "supplier": {
+        "name": "Scrapinghub"
+      },
+      "type": "library",
+      "version": "1.4.0"
+    },
+    {
+      "author": "Christian Heimes",
+      "bom-ref": "pkg:pypi/defusedxml@0.7.1",
+      "copyright": "N/A",
+      "description": "XML bomb protection for Python stdlib modules",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///defusedxml-0.7.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///defusedxml-0.7.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/tiran/defusedxml/archive/tags/v0.7.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/defusedxml/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/tiran/defusedxml"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "PSFL"
+          }
+        }
+      ],
+      "name": "defusedxml",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/defusedxml@0.7.1",
+      "supplier": {
+        "name": "Christian Heimes"
+      },
+      "type": "library",
+      "version": "0.7.1"
+    },
+    {
+      "author": "See AUTHORS.txt",
+      "bom-ref": "pkg:pypi/et-xmlfile@2.0.0",
+      "copyright": "N/A",
+      "description": "An implementation of lxml.xmlfile for the standard library",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///et_xmlfile-2.0.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///et_xmlfile-2.0.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/et-xmlfile/"
+        },
+        {
+          "type": "website",
+          "url": "https://foss.heptapod.net/openpyxl/et_xmlfile"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "et-xmlfile",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/et-xmlfile@2.0.0",
+      "supplier": {
+        "name": "See AUTHORS.txt"
+      },
+      "type": "library",
+      "version": "2.0.0"
+    },
+    {
+      "author": "Manraj Singh",
+      "bom-ref": "pkg:pypi/halo@0.0.31",
+      "copyright": "N/A",
+      "description": "Beautiful terminal spinners in Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5350488fb7d2aa7c31a1344120cee67a872901ce8858f60da7946cef96c208ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///halo-0.0.31-py2-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7b67a3521ee91d53b7152d4ee3452811e1d2a6321975137762eb3d70063cc9d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///halo-0.0.31.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5350488fb7d2aa7c31a1344120cee67a872901ce8858f60da7946cef96c208ab"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/86/e3/065611830ffe8c859130eb99336d26045c477cf55162dd92065e9f1c2938/halo-0.0.31-py2-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7b67a3521ee91d53b7152d4ee3452811e1d2a6321975137762eb3d70063cc9d6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ee/48/d53580d30b1fabf25d0d1fcc3f5b26d08d2ac75a1890ff6d262f9f027436/halo-0.0.31.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/halo/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/manrajgrover/halo"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5350488fb7d2aa7c31a1344120cee67a872901ce8858f60da7946cef96c208ab"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "halo",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/halo@0.0.31",
+      "supplier": {
+        "name": "Manraj Singh"
+      },
+      "type": "library",
+      "version": "0.0.31"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/idna@3.11",
+      "copyright": "N/A",
+      "description": "Internationalized Domain Names in Applications (IDNA)",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///idna-3.11-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///idna-3.11.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/kjd/idna/archive/tags/v3.11.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/idna/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/kjd/idna"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD-3-Clause"
+          }
+        }
+      ],
+      "name": "idna",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.11",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "3.11"
+    },
+    {
+      "author": "Barry Warsaw",
+      "bom-ref": "pkg:pypi/importlib-resources@5.13.0",
+      "copyright": "N/A",
+      "description": "Read resources from Python packages",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///importlib_resources-5.13.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "82d5c6cca930697dbbd86c93333bb2c2e72861d4789a11c2662b933e5ad2b528"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///importlib_resources-5.13.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7a/68/bd9dd6bbf06772c7accce77d0354d783333fbe712a60b08fc13540c05422/importlib_resources-5.13.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python/importlib_resources/archive/tags/v5.13.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/importlib-resources/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python/importlib_resources"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9f7bd0c97b79972a6cce36a366356d16d5e13b09679c11a58f1014bfdf8e64b2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "importlib-resources",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/importlib-resources@5.13.0",
+      "supplier": {
+        "name": "Barry Warsaw"
+      },
+      "type": "library",
+      "version": "5.13.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/jsonschema@4.26.0",
+      "copyright": "N/A",
+      "description": "An implementation of JSON Schema validation for Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///jsonschema-4.26.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///jsonschema-4.26.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python-jsonschema/jsonschema/archive/tags/v4.26.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/jsonschema/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/jsonschema"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "jsonschema",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.26.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "4.26.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/jsonschema-specifications@2025.9.1",
+      "copyright": "N/A",
+      "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///jsonschema_specifications-2025.9.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///jsonschema_specifications-2025.9.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python-jsonschema/jsonschema-specifications/archive/tags/v2025.9.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/jsonschema-specifications/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/jsonschema-specifications"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "jsonschema-specifications",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema-specifications@2025.9.1",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2025.9.1"
+    },
+    {
+      "author": "nexB. Inc. and others",
+      "bom-ref": "pkg:pypi/license-expression@30.4.4",
+      "copyright": "N/A",
+      "description": "license-expression is a comprehensive utility library to parse, compare, simplify and normalize license expressions (such as SPDX license expressions) using boolean logic.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///license_expression-30.4.4-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///license_expression-30.4.4.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/aboutcode-org/license-expression/archive/tags/v30.4.4.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/license-expression/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/aboutcode-org/license-expression"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "license-expression",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/license-expression@30.4.4",
+      "supplier": {
+        "name": "nexB. Inc. and others"
+      },
+      "type": "library",
+      "version": "30.4.4"
+    },
+    {
+      "author": "Manraj Singh",
+      "bom-ref": "pkg:pypi/log-symbols@0.0.14",
+      "copyright": "N/A",
+      "description": "Colored symbols for various log levels for Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///log_symbols-0.0.14-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///log_symbols-0.0.14.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/28/5d/d710c38be68b0fb54e645048fe359c3904cc3cb64b2de9d40e1712bf110c/log_symbols-0.0.14-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/45/87/e86645d758a4401c8c81914b6a88470634d1785c9ad09823fa4a1bd89250/log_symbols-0.0.14.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/log-symbols/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/manrajgrover/py-log-symbols"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "log-symbols",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/log-symbols@0.0.14",
+      "supplier": {
+        "name": "Manraj Singh"
+      },
+      "type": "library",
+      "version": "0.0.14"
+    },
+    {
+      "author": "See AUTHORS",
+      "bom-ref": "pkg:pypi/openpyxl@3.1.5",
+      "copyright": "N/A",
+      "description": "A Python library to read/write Excel 2010 xlsx/xlsm files",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///openpyxl-3.1.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///openpyxl-3.1.5.tar.gz"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/openpyxl/"
+        },
+        {
+          "type": "website",
+          "url": "https://openpyxl.readthedocs.io"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "openpyxl",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/openpyxl@3.1.5",
+      "supplier": {
+        "name": "See AUTHORS"
+      },
+      "type": "library",
+      "version": "3.1.5"
+    },
+    {
+      "author": "the purl authors",
+      "bom-ref": "pkg:pypi/packageurl-python@0.15.6",
+      "copyright": "N/A",
+      "description": "A purl aka. Package URL parser and builder",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a40210652c89022772a6c8340d6066f7d5dc67132141e5284a4db7a27d0a8ab0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///packageurl_python-0.15.6-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cbc89afd15d5f4d05db4f1b61297e5b97a43f61f28799f6d282aff467ed2ee96"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///packageurl_python-0.15.6.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a40210652c89022772a6c8340d6066f7d5dc67132141e5284a4db7a27d0a8ab0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4b/ca/b598e18eb0820a0116690a960d85625aae50dae8ba58195e254e35c2289a/packageurl_python-0.15.6-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/package-url/packageurl-python/archive/tags/v0.15.6.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/packageurl-python/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/package-url/packageurl-python"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a40210652c89022772a6c8340d6066f7d5dc67132141e5284a4db7a27d0a8ab0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "packageurl-python",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/packageurl-python@0.15.6",
+      "supplier": {
+        "name": "the purl authors"
+      },
+      "type": "library",
+      "version": "0.15.6"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/packaging@26.1",
+      "copyright": "N/A",
+      "description": "Core utilities for Python packages",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///packaging-26.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///packaging-26.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/pypa/packaging/archive/tags/26.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/packaging/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/pypa/packaging"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0 OR BSD-2-Clause"
+          }
+        }
+      ],
+      "name": "packaging",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/packaging@26.1",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "26.1"
+    },
+    {
+      "author": "Paul Horton",
+      "bom-ref": "pkg:pypi/py-serializable@2.1.0",
+      "copyright": "N/A",
+      "description": "Library for serializing and deserializing Python Objects to and from JSON and XML.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///py_serializable-2.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///py_serializable-2.1.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/madpah/serializable/archive/tags/v2.1.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/py-serializable/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/madpah/serializable#readme"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "py-serializable",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/py-serializable@2.1.0",
+      "supplier": {
+        "name": "Paul Horton"
+      },
+      "type": "library",
+      "version": "2.1.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/pyjwt@2.12.1",
+      "copyright": "N/A",
+      "description": "JSON Web Token implementation in Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///pyjwt-2.12.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///pyjwt-2.12.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/jpadilla/pyjwt/archive/tags/2.12.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/PyJWT/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/jpadilla/pyjwt"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "pyjwt",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/pyjwt@2.12.1",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2.12.1"
+    },
+    {
+      "author": "Gustavo Niemeyer",
+      "bom-ref": "pkg:pypi/python-dateutil@2.9.0.post0",
+      "copyright": "N/A",
+      "description": "Extensions to the standard Python datetime module",
+      "externalReferences": [
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///python-dateutil-2.9.0.post0.tar.gz"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///python_dateutil-2.9.0.post0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/dateutil/dateutil/archive/tags/2.9.0.post0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/python-dateutil/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/dateutil/dateutil"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Dual License"
+          }
+        }
+      ],
+      "name": "python-dateutil",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/python-dateutil@2.9.0.post0",
+      "supplier": {
+        "name": "Gustavo Niemeyer"
+      },
+      "type": "library",
+      "version": "2.9.0.post0"
+    },
+    {
+      "author": "Stuart Bishop",
+      "bom-ref": "pkg:pypi/pytz@2026.1.post1",
+      "copyright": "N/A",
+      "description": "World timezone definitions, modern and historical",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///pytz-2026.1.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///pytz-2026.1.post1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/pytz/"
+        },
+        {
+          "type": "website",
+          "url": "http://pythonhosted.org/pytz"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "pytz",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/pytz@2026.1.post1",
+      "supplier": {
+        "name": "Stuart Bishop"
+      },
+      "type": "library",
+      "version": "2026.1.post1"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/referencing@0.37.0",
+      "copyright": "N/A",
+      "description": "JSON Referencing + Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///referencing-0.37.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///referencing-0.37.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python-jsonschema/referencing/archive/tags/v0.37.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/referencing/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python-jsonschema/referencing"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "referencing",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/referencing@0.37.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "0.37.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/regex@2026.4.4",
+      "copyright": "N/A",
+      "description": "Alternative regular expression module, to replace re.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74fa82dcc8143386c7c0392e18032009d1db715c25f4ba22d23dc2e04d02a20f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a85b620a388d6c9caa12189233109e236b3da3deffe4ff11b84ae84e218a274f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2895506ebe32cc63eeed8f80e6eae453171cfccccab35b70dc3129abec35a5b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6780f008ee81381c737634e75c24e5a6569cc883c4f8e37a37917ee79efcafd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88e9b048345c613f253bea4645b2fe7e579782b82cac99b1daad81e29cc2ed8e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be061028481186ba62a0f4c5f1cc1e3d5ab8bce70c89236ebe01023883bc903b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2228c02b368d69b724c36e96d3d1da721561fb9cc7faa373d7bf65e07d75cb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0540e5b733618a2f84e9cb3e812c8afa82e151ca8e19cf6c4e95c5a65198236f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf9b1b2e692d4877880388934ac746c99552ce6bf40792a767fd42c8c99f136d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "011bb48bffc1b46553ac704c975b3348717f4e4aa7a67522b51906f99da1820c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8512fcdb43f1bf18582698a478b5ab73f9c1667a5b7548761329ef410cd0a760"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "867bddc63109a0276f5a31999e4c8e0eb7bbbad7d6166e28d969a2c1afeb97f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b9a00b83f3a40e09859c78920571dcb83293c8004079653dd22ec14bbfa98c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e355be718caf838aa089870259cf1776dc2a4aa980514af9d02c59544d9a8b22"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33bfda9684646d323414df7abe5692c61d297dbb0530b28ec66442e768813c59"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0709f22a56798457ae317bcce42aacee33c680068a8f14097430d9f9ba364bee"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee9627de8587c1a22201cb16d0296ab92b4df5cdcb5349f4e9744d61db7c7c98"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp310-cp310-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp313-cp313t-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4-cp314-cp314t-win_arm64.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///regex-2026.4.4.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e355be718caf838aa089870259cf1776dc2a4aa980514af9d02c59544d9a8b22"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/01/da/cc78710ea2e60b10bacfcc9beb18c67514200ab03597b3b2b319995785c2/regex-2026.4.4-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/05/21/bac05d806ed02cd4b39d9c8e5b5f9a2998c94c3a351b7792e80671fa5315/regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74fa82dcc8143386c7c0392e18032009d1db715c25f4ba22d23dc2e04d02a20f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/12/59/fd98f8fd54b3feaa76a855324c676c17668c5a1121ec91b7ec96b01bf865/regex-2026.4.4-cp310-cp310-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6780f008ee81381c737634e75c24e5a6569cc883c4f8e37a37917ee79efcafd9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/14/bc/f5dcf04fd462139dcd75495c02eee22032ef741cfa151386a39c3f5fc9b5/regex-2026.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2895506ebe32cc63eeed8f80e6eae453171cfccccab35b70dc3129abec35a5b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/16/7f/3fab9709b0b0060ba81a04b8a107b34147cd14b9c5551b772154d6505504/regex-2026.4.4-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d2228c02b368d69b724c36e96d3d1da721561fb9cc7faa373d7bf65e07d75cb5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1a/b9/7cd0ceb58cd99c70806241636640ae15b4a3fe62e22e9b99afa67a0d7965/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1c/3c/39f19f47f19dcefa3403f09d13562ca1c0fd07ab54db2bc03148f3f6b46a/regex-2026.4.4-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/96/9647dd7f2ecf6d9ce1fb04dfdb66910d094e10d8fe53e9c15096d8aa0bd2/regex-2026.4.4-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/e6/bf057227144d02e3ba758b66649e87531d744dda5f3254f48660f18ae9d8/regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/29/ce/7605048f00e1379eba89d610c7d644d8f695dc9b26d3b6ecfa3132b872ff/regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0540e5b733618a2f84e9cb3e812c8afa82e151ca8e19cf6c4e95c5a65198236f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2c/fb/c58e3ea40ed183806ccbac05c29a3e8c2f88c1d3a66ed27860d5cad7c62d/regex-2026.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/33/80/74e13262460530c3097ff343a17de9a34d040a5dc4de9cf3a8241faab51c/regex-2026.4.4-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "88e9b048345c613f253bea4645b2fe7e579782b82cac99b1daad81e29cc2ed8e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/37/36/8a906e216d5b4de7ec3788c1d589b45db40c1c9580cd7b326835cfc976d4/regex-2026.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8512fcdb43f1bf18582698a478b5ab73f9c1667a5b7548761329ef410cd0a760"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3e/db/6ae74ef8a4cfead341c367e4eed45f71fb1aaba35827a775eed4f1ba4f74/regex-2026.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "867bddc63109a0276f5a31999e4c8e0eb7bbbad7d6166e28d969a2c1afeb97f9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/53/9a/f7f2c1c6b610d7c6de1c3dc5951effd92c324b1fde761af2044b4721020f/regex-2026.4.4-cp310-cp310-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf9b1b2e692d4877880388934ac746c99552ce6bf40792a767fd42c8c99f136d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/54/a9/53790fc7a6c948a7be2bc7214fd9cabdd0d1ba561b0f401c91f4ff0357f0/regex-2026.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a85b620a388d6c9caa12189233109e236b3da3deffe4ff11b84ae84e218a274f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6c/64/d0f222f68e3579d50babf0e4fcc9c9639ef0587fecc00b15e1e46bfc32fa/regex-2026.4.4-cp310-cp310-macosx_10_9_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/85/30/56547b80f34f4dd2986e1cdd63b1712932f63b6c4ce2f79c50a6cd79d1c2/regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee9627de8587c1a22201cb16d0296ab92b4df5cdcb5349f4e9744d61db7c7c98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/87/8b/4327eeb9dbb4b098ebecaf02e9f82b79b6077beeb54c43d9a0660cf7c44c/regex-2026.4.4-cp310-cp310-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8b/fb/7f3b772be101373c8626ed34c5d727dcbb8abd42a7b1219bc25fd9a3cc04/regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33bfda9684646d323414df7abe5692c61d297dbb0530b28ec66442e768813c59"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a2/5f/c7bcba41529105d6c2ca7080ecab7184cd00bee2e1ad1fdea80e618704ea/regex-2026.4.4-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "be061028481186ba62a0f4c5f1cc1e3d5ab8bce70c89236ebe01023883bc903b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a5/bb/bad2d79be0917a6ef31f5e0f161d9265cb56fd90a3ae1d2e8d991882a48b/regex-2026.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ac/2f/ce060fdfea8eff34a8997603532e44cdb7d1f35e3bc253612a8707a90538/regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ad/64/933321aa082a2c6ee2785f22776143ba89840189c20d3b6b1d12b6aae16b/regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/17/c65d1d8ae90b772d5758eb4014e1e011bb2db353fc4455432e6cc9100df7/regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b9a00b83f3a40e09859c78920571dcb83293c8004079653dd22ec14bbfa98c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/dd/55/e5386d393bbf8b43c8b084703a46d635e7b2bdc6e0f5909a2619ea1125f1/regex-2026.4.4-cp310-cp310-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e0/7a/617356cbecdb452812a5d42f720d6d5096b360d4a4c1073af700ea140ad2/regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "011bb48bffc1b46553ac704c975b3348717f4e4aa7a67522b51906f99da1820c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e3/3c/29ca44729191c79f5476538cd0fa04fa2553b3c45508519ecea4c7afa8f6/regex-2026.4.4-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e5/44/810cb113096a1dacbe82789fbfab2823f79d19b7f1271acecb7009ba9b88/regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e9/77/283e0d5023fde22cd9e86190d6d9beb21590a452b195ffe00274de470691/regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0709f22a56798457ae317bcce42aacee33c680068a8f14097430d9f9ba364bee"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/eb/26/a745729c2c49354ec4f4bce168f29da932ca01b4758227686cc16c7dde1b/regex-2026.4.4-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/eb/3b/637181b787dd1a820ba1c712cee2b4144cd84a32dc776ca067b12b2d70c8/regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/mrabarnett/mrab-regex/archive/tags/2026.4.4.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/regex/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/mrabarnett/mrab-regex"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0 AND CNRI-Python"
+          }
+        }
+      ],
+      "name": "regex",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/regex@2026.4.4",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2026.4.4"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/requests@2.33.1",
+      "copyright": "N/A",
+      "description": "Python HTTP for Humans.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///requests-2.33.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///requests-2.33.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/psf/requests/archive/tags/v2.33.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/requests/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/psf/requests"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "requests",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.33.1",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2.33.1"
+    },
+    {
+      "author": "Paul Horton",
+      "bom-ref": "pkg:pypi/requirements-parser@0.11.0",
+      "copyright": "N/A",
+      "description": "This is a small Python module for parsing Pip requirement files.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50379eb50311834386c2568263ae5225d7b9d0867fb55cf4ecc93959de2c2684"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///requirements_parser-0.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "35f36dc969d14830bf459803da84f314dc3d17c802592e9e970f63d0359e5920"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///requirements_parser-0.11.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "50379eb50311834386c2568263ae5225d7b9d0867fb55cf4ecc93959de2c2684"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/88/33/190393a7d36872e237cbc99e6c44d9a078a1ba7b406462fe6eafd5a28e04/requirements_parser-0.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/madpah/requirements-parser//archive/tags/v0.11.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/requirements-parser/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/madpah/requirements-parser/#readme"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "50379eb50311834386c2568263ae5225d7b9d0867fb55cf4ecc93959de2c2684"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "requirements-parser",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/requirements-parser@0.11.0",
+      "supplier": {
+        "name": "Paul Horton"
+      },
+      "type": "library",
+      "version": "0.11.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/rpds-py@0.30.0",
+      "copyright": "N/A",
+      "description": "Python bindings to Rust's persistent data structures (rpds)",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp313-cp313t-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///rpds_py-0.30.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/crate-py/rpds/archive/tags/v0.30.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/rpds-py/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/crate-py/rpds"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "rpds-py",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/rpds-py@0.30.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "0.30.0"
+    },
+    {
+      "author": "Kostiantyn Rybnikov",
+      "bom-ref": "pkg:pypi/semver@3.0.2",
+      "copyright": "N/A",
+      "description": "Python helper for Semantic Versioning (https://semver.org)",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///semver-3.0.2-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///semver-3.0.2.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9a/77/0cc7a8a3bc7e53d07e8f47f147b92b0960e902b8254859f4aee5c4d7866b/semver-3.0.2-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python-semver/python-semver/archive/tags/3.0.2.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/semver/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python-semver/python-semver"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "BSD"
+          }
+        }
+      ],
+      "name": "semver",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/semver@3.0.2",
+      "supplier": {
+        "name": "Kostiantyn Rybnikov"
+      },
+      "type": "library",
+      "version": "3.0.2"
+    },
+    {
+      "author": "Benjamin Peterson",
+      "bom-ref": "pkg:pypi/six@1.17.0",
+      "copyright": "N/A",
+      "description": "Python 2 and 3 compatibility utilities",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///six-1.17.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///six-1.17.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/benjaminp/six/archive/tags/1.17.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/six/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/benjaminp/six"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "six",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.17.0",
+      "supplier": {
+        "name": "Benjamin Peterson"
+      },
+      "type": "library",
+      "version": "1.17.0"
+    },
+    {
+      "author": "Grant Jenks",
+      "bom-ref": "pkg:pypi/sortedcontainers@2.4.0",
+      "copyright": "N/A",
+      "description": "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///sortedcontainers-2.4.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///sortedcontainers-2.4.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/sortedcontainers/"
+        },
+        {
+          "type": "website",
+          "url": "http://www.grantjenks.com/docs/sortedcontainers/"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache 2.0"
+          }
+        }
+      ],
+      "name": "sortedcontainers",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/sortedcontainers@2.4.0",
+      "supplier": {
+        "name": "Grant Jenks"
+      },
+      "type": "library",
+      "version": "2.4.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/soupsieve@2.8.3",
+      "copyright": "N/A",
+      "description": "A modern CSS selector implementation for Beautiful Soup.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///soupsieve-2.8.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///soupsieve-2.8.3.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/facelessuser/soupsieve/archive/tags/2.8.3.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/soupsieve/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/facelessuser/soupsieve"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "soupsieve",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/soupsieve@2.8.3",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2.8.3"
+    },
+    {
+      "author": "Manraj Singh",
+      "bom-ref": "pkg:pypi/spinners@0.0.24",
+      "copyright": "N/A",
+      "description": "Spinners for terminals",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///spinners-0.0.24-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///spinners-0.0.24.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9f/8e/3310207a68118000ca27ac878b8386123628b335ecb3d4bec4743357f0d1/spinners-0.0.24-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/d3/91/bb331f0a43e04d950a710f402a0986a54147a35818df0e1658551c8d12e1/spinners-0.0.24.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/spinners/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/manrajgrover/py-spinners"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "spinners",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/spinners@0.0.24",
+      "supplier": {
+        "name": "Manraj Singh"
+      },
+      "type": "library",
+      "version": "0.0.24"
+    },
+    {
+      "author": "Thomas Graf",
+      "bom-ref": "pkg:pypi/sw360@1.11.0",
+      "copyright": "N/A",
+      "description": "Python interface to the SW360 software component catalogue",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebf94ce8a33af46b974a0a36f772b36435133a8d7df705a24fcd42d41edbfea4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///sw360-1.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "38b4f68c8c03e325bbd604cb2602763cd1fca955a4a18e2b537751235d34e375"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///sw360-1.11.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ebf94ce8a33af46b974a0a36f772b36435133a8d7df705a24fcd42d41edbfea4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/9c/ad/cc884c11464df5d2bae5cde894cb6c90ae1d3154726ca546c7897e7bb56b/sw360-1.11.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/sw360/sw360python/archive/refs/tags/V1.11.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/sw360/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/sw360/sw360python"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ebf94ce8a33af46b974a0a36f772b36435133a8d7df705a24fcd42d41edbfea4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "sw360",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/sw360@1.11.0",
+      "supplier": {
+        "name": "Thomas Graf"
+      },
+      "type": "library",
+      "version": "1.11.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/termcolor@3.3.0",
+      "copyright": "N/A",
+      "description": "ANSI color formatting for output in terminal",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///termcolor-3.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///termcolor-3.3.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/termcolor/termcolor/archive/tags/3.3.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/termcolor/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/termcolor/termcolor"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "termcolor",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/termcolor@3.3.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "3.3.0"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/types-setuptools@82.0.0.20260408",
+      "copyright": "N/A",
+      "description": "Typing stubs for setuptools",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///types_setuptools-82.0.0.20260408-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///types_setuptools-82.0.0.20260408.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/3d/e1/46a4fc3ef03aabf5d18bac9df5cf37c6b02c3bddf3e05c3533f4b4588331/types_setuptools-82.0.0.20260408-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c3/12/3464b410c50420dd4674fa5fe9d3880711c1dbe1a06f5fe4960ee9067b9e/types_setuptools-82.0.0.20260408.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/types-setuptools/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python/typeshed"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "types-setuptools",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/types-setuptools@82.0.0.20260408",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "82.0.0.20260408"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/typing-extensions@4.15.0",
+      "copyright": "N/A",
+      "description": "Backported and Experimental Type Hints for Python 3.9+",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///typing_extensions-4.15.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///typing_extensions-4.15.0.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python/typing_extensions/archive/tags/4.15.0.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/typing-extensions/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python/typing_extensions"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "PSF-2.0"
+          }
+        }
+      ],
+      "name": "typing-extensions",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/typing-extensions@4.15.0",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "4.15.0"
+    },
+    {
+      "author": "Python Software Foundation",
+      "bom-ref": "pkg:pypi/tzdata@2026.1",
+      "copyright": "N/A",
+      "description": "Provider of IANA time zone data",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///tzdata-2026.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///tzdata-2026.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/python/tzdata/archive/tags/2026.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/tzdata/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/python/tzdata"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache-2.0"
+          }
+        }
+      ],
+      "name": "tzdata",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/tzdata@2026.1",
+      "supplier": {
+        "name": "Python Software Foundation"
+      },
+      "type": "library",
+      "version": "2026.1"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/tzlocal@5.3.1",
+      "copyright": "N/A",
+      "description": "tzinfo object for the local timezone",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///tzlocal-5.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///tzlocal-5.3.1.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/regebro/tzlocal/archive/tags/5.3.1.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/tzlocal/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/regebro/tzlocal"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "tzlocal",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/tzlocal@5.3.1",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "5.3.1"
+    },
+    {
+      "author": "N/A",
+      "bom-ref": "pkg:pypi/urllib3@2.6.3",
+      "copyright": "N/A",
+      "description": "HTTP library with thread-safe connection pooling, file post, and more.",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///urllib3-2.6.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///urllib3-2.6.3.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/urllib3/urllib3/archive/tags/2.6.3.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/urllib3/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/urllib3/urllib3"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@2.6.3",
+      "supplier": {
+        "name": "N/A"
+      },
+      "type": "library",
+      "version": "2.6.3"
+    },
+    {
+      "author": "Ben Mather",
+      "bom-ref": "pkg:pypi/validation@0.8.3",
+      "copyright": "N/A",
+      "description": "A library for runtime type checking and validation of python values",
+      "externalReferences": [
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4aed7dd548b5ad3ba12306cda7322658490e22dedef29295fdb8692b1b4fe3a"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///validation-0.8.3.tar.gz"
+        },
+        {
+          "comment": "source archive (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "c4aed7dd548b5ad3ba12306cda7322658490e22dedef29295fdb8692b1b4fe3a"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/ba/f7/0271494d63791033cc993d446f55f86d8c59a45935981b450def3457494e/validation-0.8.3.tar.gz"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/validation/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/bwhmather/python-validation"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "Apache Software License"
+          }
+        }
+      ],
+      "name": "validation",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/validation@0.8.3",
+      "supplier": {
+        "name": "Ben Mather"
+      },
+      "type": "library",
+      "version": "0.8.3"
+    },
+    {
+      "author": "Daniel Holth",
+      "bom-ref": "pkg:pypi/wheel@0.38.4",
+      "copyright": "N/A",
+      "description": "A built-package format for Python",
+      "externalReferences": [
+        {
+          "comment": "relativePath",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///wheel-0.38.4-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (local copy)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac"
+            }
+          ],
+          "type": "distribution",
+          "url": "file:///wheel-0.38.4.tar.gz"
+        },
+        {
+          "comment": "binary (download location)",
+          "hashes": [
+            {
+              "alg": "SHA-256",
+              "content": "b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"
+            }
+          ],
+          "type": "distribution",
+          "url": "https://files.pythonhosted.org/packages/bd/7c/d38a0b30ce22fc26ed7dbc087c6d00851fb3395e9d0dac40bec1f905030c/wheel-0.38.4-py3-none-any.whl"
+        },
+        {
+          "comment": "source archive (download location)",
+          "type": "distribution",
+          "url": "https://github.com/pypa/wheel/archive/tags/0.38.4.zip"
+        },
+        {
+          "comment": "PyPi URL",
+          "type": "distribution",
+          "url": "https://pypi.org/project/wheel/"
+        },
+        {
+          "type": "website",
+          "url": "https://github.com/pypa/wheel"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "wheel",
+      "properties": [
+        {
+          "name": "siemens:primaryLanguage",
+          "value": "Python"
+        }
+      ],
+      "purl": "pkg:pypi/wheel@0.38.4",
+      "supplier": {
+        "name": "Daniel Holth"
+      },
+      "type": "library",
+      "version": "0.38.4"
+    }
+  ],
+  "definitions": {
+    "standards": [
+      {
+        "bom-ref": "standard-bom",
+        "description": "The Standard for Software Bills of Materials in Siemens",
+        "externalReferences": [
+          {
+            "type": "website",
+            "url": "https://sbom.siemens.io/"
+          }
+        ],
+        "name": "Standard BOM",
+        "owner": "Siemens AG",
+        "version": "3.0.0"
+      }
+    ]
+  },
+  "dependencies": [
+    {
+      "ref": "pkg:pypi/attrs@26.1.0"
+    },
+    {
+      "ref": "pkg:pypi/beautifulsoup4@4.14.3"
+    },
+    {
+      "ref": "pkg:pypi/boolean-py@5.0"
+    },
+    {
+      "dependsOn": [
+        "pkg:pypi/attrs@26.1.0",
+        "pkg:pypi/beautifulsoup4@4.14.3",
+        "pkg:pypi/boolean-py@5.0",
+        "pkg:pypi/certifi@2026.2.25",
+        "pkg:pypi/chardet@5.2.0",
+        "pkg:pypi/charset-normalizer@3.4.7",
+        "pkg:pypi/cli-support@2.0.1",
+        "pkg:pypi/colorama@0.4.6",
+        "pkg:pypi/cyclonedx-python-lib@11.7.0",
+        "pkg:pypi/dateparser@1.4.0",
+        "pkg:pypi/defusedxml@0.7.1",
+        "pkg:pypi/et-xmlfile@2.0.0",
+        "pkg:pypi/halo@0.0.31",
+        "pkg:pypi/idna@3.11",
+        "pkg:pypi/importlib-resources@5.13.0",
+        "pkg:pypi/jsonschema-specifications@2025.9.1",
+        "pkg:pypi/jsonschema@4.26.0",
+        "pkg:pypi/license-expression@30.4.4",
+        "pkg:pypi/log-symbols@0.0.14",
+        "pkg:pypi/openpyxl@3.1.5",
+        "pkg:pypi/packageurl-python@0.15.6",
+        "pkg:pypi/packaging@26.1",
+        "pkg:pypi/py-serializable@2.1.0",
+        "pkg:pypi/pyjwt@2.12.1",
+        "pkg:pypi/python-dateutil@2.9.0.post0",
+        "pkg:pypi/pytz@2026.1.post1",
+        "pkg:pypi/referencing@0.37.0",
+        "pkg:pypi/regex@2026.4.4",
+        "pkg:pypi/requests@2.33.1",
+        "pkg:pypi/requirements-parser@0.11.0",
+        "pkg:pypi/rpds-py@0.30.0",
+        "pkg:pypi/semver@3.0.2",
+        "pkg:pypi/six@1.17.0",
+        "pkg:pypi/sortedcontainers@2.4.0",
+        "pkg:pypi/soupsieve@2.8.3",
+        "pkg:pypi/spinners@0.0.24",
+        "pkg:pypi/sw360@1.11.0",
+        "pkg:pypi/termcolor@3.3.0",
+        "pkg:pypi/types-setuptools@82.0.0.20260408",
+        "pkg:pypi/typing-extensions@4.15.0",
+        "pkg:pypi/tzdata@2026.1",
+        "pkg:pypi/tzlocal@5.3.1",
+        "pkg:pypi/urllib3@2.6.3",
+        "pkg:pypi/validation@0.8.3",
+        "pkg:pypi/wheel@0.38.4"
+      ],
+      "ref": "pkg:pypi/capycli@2.11.1"
+    },
+    {
+      "ref": "pkg:pypi/certifi@2026.2.25"
+    },
+    {
+      "ref": "pkg:pypi/chardet@5.2.0"
+    },
+    {
+      "ref": "pkg:pypi/charset-normalizer@3.4.7"
+    },
+    {
+      "ref": "pkg:pypi/cli-support@2.0.1"
+    },
+    {
+      "ref": "pkg:pypi/colorama@0.4.6"
+    },
+    {
+      "ref": "pkg:pypi/cyclonedx-python-lib@11.7.0"
+    },
+    {
+      "ref": "pkg:pypi/dateparser@1.4.0"
+    },
+    {
+      "ref": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "ref": "pkg:pypi/et-xmlfile@2.0.0"
+    },
+    {
+      "ref": "pkg:pypi/halo@0.0.31"
+    },
+    {
+      "ref": "pkg:pypi/idna@3.11"
+    },
+    {
+      "ref": "pkg:pypi/importlib-resources@5.13.0"
+    },
+    {
+      "ref": "pkg:pypi/jsonschema-specifications@2025.9.1"
+    },
+    {
+      "ref": "pkg:pypi/jsonschema@4.26.0"
+    },
+    {
+      "ref": "pkg:pypi/license-expression@30.4.4"
+    },
+    {
+      "ref": "pkg:pypi/log-symbols@0.0.14"
+    },
+    {
+      "ref": "pkg:pypi/openpyxl@3.1.5"
+    },
+    {
+      "ref": "pkg:pypi/packageurl-python@0.15.6"
+    },
+    {
+      "ref": "pkg:pypi/packaging@26.1"
+    },
+    {
+      "ref": "pkg:pypi/py-serializable@2.1.0"
+    },
+    {
+      "ref": "pkg:pypi/pyjwt@2.12.1"
+    },
+    {
+      "ref": "pkg:pypi/python-dateutil@2.9.0.post0"
+    },
+    {
+      "ref": "pkg:pypi/pytz@2026.1.post1"
+    },
+    {
+      "ref": "pkg:pypi/referencing@0.37.0"
+    },
+    {
+      "ref": "pkg:pypi/regex@2026.4.4"
+    },
+    {
+      "ref": "pkg:pypi/requests@2.33.1"
+    },
+    {
+      "ref": "pkg:pypi/requirements-parser@0.11.0"
+    },
+    {
+      "ref": "pkg:pypi/rpds-py@0.30.0"
+    },
+    {
+      "ref": "pkg:pypi/semver@3.0.2"
+    },
+    {
+      "ref": "pkg:pypi/six@1.17.0"
+    },
+    {
+      "ref": "pkg:pypi/sortedcontainers@2.4.0"
+    },
+    {
+      "ref": "pkg:pypi/soupsieve@2.8.3"
+    },
+    {
+      "ref": "pkg:pypi/spinners@0.0.24"
+    },
+    {
+      "ref": "pkg:pypi/sw360@1.11.0"
+    },
+    {
+      "ref": "pkg:pypi/termcolor@3.3.0"
+    },
+    {
+      "ref": "pkg:pypi/types-setuptools@82.0.0.20260408"
+    },
+    {
+      "ref": "pkg:pypi/typing-extensions@4.15.0"
+    },
+    {
+      "ref": "pkg:pypi/tzdata@2026.1"
+    },
+    {
+      "ref": "pkg:pypi/tzlocal@5.3.1"
+    },
+    {
+      "ref": "pkg:pypi/urllib3@2.6.3"
+    },
+    {
+      "ref": "pkg:pypi/validation@0.8.3"
+    },
+    {
+      "ref": "pkg:pypi/wheel@0.38.4"
+    }
+  ],
+  "metadata": {
+    "authors": [
+      {
+        "name": "CaPyCLI"
+      }
+    ],
+    "component": {
+      "author": "Thomas Graf",
+      "bom-ref": "pkg:pypi/capycli@2.11.1",
+      "copyright": "Siemens AG",
+      "description": "CaPyCli - Clearing Automation Python Command Line Interface for SW360",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "name": "capycli",
+      "purl": "pkg:pypi/capycli@2.11.1",
+      "supplier": {
+        "name": "Thomas Graf"
+      },
+      "type": "library",
+      "version": "2.11.1"
+    },
+    "licenses": [
+      {
+        "license": {
+          "id": "CC0-1.0"
+        }
+      }
+    ],
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
+    "properties": [
+      {
+        "name": "siemens:profile",
+        "value": "clearing"
+      }
+    ],
+    "timestamp": "2026-04-15T15:13:29.097716+00:00",
+    "tools": {
+      "components": [
+        {
+          "externalReferences": [
+            {
+              "type": "website",
+              "url": "https://github.com/sw360/capycli"
+            }
+          ],
+          "name": "CaPyCLI",
+          "supplier": {
+            "name": "Siemens AG"
+          },
+          "type": "application",
+          "version": "2.11.0"
+        }
+      ]
+    }
+  },
+  "serialNumber": "urn:uuid:6a325c17-2e9a-4231-8789-11630b5ac988",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "compositions": [
+    {
+      "aggregate": "unknown"
+    }
+  ]
+}

--- a/capycli/bom/filter_bom.py
+++ b/capycli/bom/filter_bom.py
@@ -118,9 +118,8 @@ class FilterBom(capycli.common.script_base.ScriptBase):
         if source_file_url:
             CycloneDxSupport.update_or_set_ext_ref(
                 component,
-                ExternalReferenceType.DISTRIBUTION,
-                CaPyCliBom.SOURCE_URL_COMMENT,
-                value=source_file_url)
+                ExternalReferenceType.SOURCE_DISTRIBUTION,
+                "", value=source_file_url)
 
         if ("SourceFile" in filterentry) and filterentry.get("SourceFile", ""):
             CycloneDxSupport.update_or_set_ext_ref(

--- a/capycli/bom/findsources.py
+++ b/capycli/bom/findsources.py
@@ -713,9 +713,8 @@ class FindSources(capycli.common.script_base.ScriptBase):
                     found_count += 1
                     CycloneDxSupport.update_or_set_ext_ref(
                         component,
-                        ExternalReferenceType.DISTRIBUTION,
-                        CaPyCliBom.SOURCE_URL_COMMENT,
-                        source_url)
+                        ExternalReferenceType.SOURCE_DISTRIBUTION,
+                        "", source_url)
                     print_green("      Found source code: " + source_url)
                 else:
                     print_green("      Found source code URL found, but not accessible!")

--- a/capycli/bom/legacy.py
+++ b/capycli/bom/legacy.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2023-2025 Siemens
+# Copyright (c) 2023-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -164,8 +164,7 @@ class LegacySupport():
             sourceUrl = item.get("SourceUrl", "")
             if sourceUrl:
                 ext_ref = ExternalReference(
-                    type=ExternalReferenceType.DISTRIBUTION,
-                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                    type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                     url=XsUri(sourceUrl))
                 hash = item.get("SourceFileHash", "")
                 if hash:
@@ -177,8 +176,7 @@ class LegacySupport():
         sourceFile = item.get("SourceFile", "")
         if sourceFile:
             ext_ref = ExternalReference(
-                type=ExternalReferenceType.DISTRIBUTION,
-                comment="source archive (local copy)",
+                type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                 url=XsUri(sourceFile))
             hash = item.get("SourceFileHash", "")
             if hash:

--- a/capycli/bom/legacy_cx.py
+++ b/capycli/bom/legacy_cx.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2023-2025 Siemens
+# Copyright (c) 2023-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -87,8 +87,7 @@ class LegacyCx(CaPyCliBom):
             if not file_uri.startswith("file://"):
                 file_uri = "file:///" + file_uri
             ext_ref = ExternalReference(
-                type=ExternalReferenceType.DISTRIBUTION,
-                comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                 url=XsUri(file_uri))
             prop2 = CycloneDxSupport.get_property(component, "source-file-hash")
             if prop2:

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -584,7 +584,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
         if value_match:
             ext_ref = CycloneDxSupport.get_ext_ref(
                 component,
-                ExternalReferenceType.SOURCE_DISTRIBUTION, "")
+                ExternalReferenceType.SOURCE_DISTRIBUTION, None)
             if not ext_ref:
                 # legacy
                 ext_ref = CycloneDxSupport.get_ext_ref(

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -584,7 +584,7 @@ class MapBom(capycli.common.script_base.ScriptBase):
         if value_match:
             ext_ref = CycloneDxSupport.get_ext_ref(
                 component,
-                ExternalReferenceType.SOURCE_DISTRIBUTION, None)
+                ExternalReferenceType.SOURCE_DISTRIBUTION, "")
             if not ext_ref:
                 # legacy
                 ext_ref = CycloneDxSupport.get_ext_ref(

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -584,14 +584,12 @@ class MapBom(capycli.common.script_base.ScriptBase):
         if value_match:
             ext_ref = CycloneDxSupport.get_ext_ref(
                 component,
-                ExternalReferenceType.DISTRIBUTION,
-                CaPyCliBom.SOURCE_URL_COMMENT)
+                ExternalReferenceType.SOURCE_DISTRIBUTION, "")
             if not ext_ref:
                 CycloneDxSupport.update_or_set_ext_ref(
                     component,
-                    ExternalReferenceType.DISTRIBUTION,
-                    CaPyCliBom.SOURCE_URL_COMMENT,
-                    value_match)
+                    ExternalReferenceType.SOURCE_DISTRIBUTION,
+                    "", value_match)
             elif str(ext_ref.url) == "":
                 ext_ref.url = XsUri(value_match)
 

--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -586,6 +586,11 @@ class MapBom(capycli.common.script_base.ScriptBase):
                 component,
                 ExternalReferenceType.SOURCE_DISTRIBUTION, "")
             if not ext_ref:
+                # legacy
+                ext_ref = CycloneDxSupport.get_ext_ref(
+                    component,
+                    ExternalReferenceType.DISTRIBUTION, "source archive (download location)")
+            if not ext_ref:
                 CycloneDxSupport.update_or_set_ext_ref(
                     component,
                     ExternalReferenceType.SOURCE_DISTRIBUTION,

--- a/capycli/common/capycli_bom_support.py
+++ b/capycli/common/capycli_bom_support.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2023-2025 Siemens
+# Copyright (c) 2023-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -118,8 +118,12 @@ class CycloneDxSupport():
     @staticmethod
     def get_ext_ref(comp: Component, type: ExternalReferenceType, comment: str) -> Optional[ExternalReference]:
         for ext_ref in comp.external_references:
-            if (ext_ref.type == type) and (ext_ref.comment == comment):
-                return ext_ref
+            if comment:
+                if (ext_ref.type == type) and (ext_ref.comment == comment):
+                    return ext_ref
+            else:
+                if ext_ref.type == type:
+                    return ext_ref
 
         return None
 
@@ -148,9 +152,14 @@ class CycloneDxSupport():
     def update_or_set_ext_ref(comp: Component, type: ExternalReferenceType, comment: str, value: str) -> None:
         ext_ref = None
         for er in comp.external_references:
-            if (er.type == type) and (er.comment == comment):
-                ext_ref = er
-                break
+            if comment:
+                if (er.type == type) and (er.comment == comment):
+                    ext_ref = er
+                    break
+            else:
+                if er.type == type:
+                    ext_ref = er
+                    break
 
         if ext_ref:
             if isinstance(value, XsUri):
@@ -158,7 +167,10 @@ class CycloneDxSupport():
             else:
                 ext_ref.url = XsUri(value)
         else:
-            CycloneDxSupport.set_ext_ref(comp, type, comment, value)
+            if comment:
+                CycloneDxSupport.set_ext_ref(comp, type, comment, value)
+            else:
+                CycloneDxSupport.set_ext_ref(comp, type, "", value)
 
     @staticmethod
     def have_relative_ext_ref_path(ext_ref: ExternalReference, rel_to: str) -> str:
@@ -213,12 +225,13 @@ class CycloneDxSupport():
     @staticmethod
     def get_ext_ref_source_url(comp: Component) -> Any:
         for ext_ref in comp.external_references:
-            if (ext_ref.type == ExternalReferenceType.DISTRIBUTION) \
-                    and (ext_ref.comment == CaPyCliBom.SOURCE_URL_COMMENT):
-                return ext_ref.url
-
             # new for CyCloneDX 1.6
             if (ext_ref.type == ExternalReferenceType.SOURCE_DISTRIBUTION):
+                return ext_ref.url
+
+            # legacy
+            if (ext_ref.type == ExternalReferenceType.DISTRIBUTION) \
+                    and (ext_ref.comment == "source archive (download location)"):
                 return ext_ref.url
 
         return ""
@@ -492,7 +505,7 @@ class CaPyCliBom():
     """
 
     # external reference comments for CaPyCLI/Siemens Standard BOM
-    SOURCE_URL_COMMENT = "source archive (download location)"
+    # SOURCE_URL_COMMENT = "source archive (download location)"
     SOURCE_FILE_COMMENT = "source archive (local copy)"
     BINARY_URL_COMMENT = "binary (download location)"
     BINARY_FILE_COMMENT = "relativePath"

--- a/capycli/dependencies/javascript.py
+++ b/capycli/dependencies/javascript.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2019-2025 Siemens
+# Copyright (c) 2019-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com, sameer.panda@siemens.com
 #
@@ -240,8 +240,7 @@ class GetJavascriptDependencies(capycli.common.dependencies_base.DependenciesBas
             url = url.replace('git+ssh://git@/', '')
             url = url.replace('ssh://git@', '')
             ext_ref = ExternalReference(
-                type=ExternalReferenceType.DISTRIBUTION,
-                comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                 url=XsUri(url))
             bomitem.external_references.add(ext_ref)
         if "github.com" in url:
@@ -251,9 +250,8 @@ class GetJavascriptDependencies(capycli.common.dependencies_base.DependenciesBas
             if url:
                 CycloneDxSupport.update_or_set_ext_ref(
                     bomitem,
-                    ExternalReferenceType.DISTRIBUTION,
-                    CaPyCliBom.SOURCE_URL_COMMENT,
-                    url)
+                    ExternalReferenceType.SOURCE_DISTRIBUTION,
+                    "", url)
             else:
                 print_yellow(
                     "  No source archive found for component " +

--- a/capycli/dependencies/maven_list.py
+++ b/capycli/dependencies/maven_list.py
@@ -166,7 +166,7 @@ class GetJavaMavenTreeDependencies(capycli.common.dependencies_base.Dependencies
                         # bomitem["SourceUrl"] = url
                         src_file_url = self.find_source_file(url, cx_comp.name, version)
                         CycloneDxSupport.update_or_set_ext_ref(
-                            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", src_file_url)
+                            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, src_file_url)
 
                         print(src_file_url)
             description = info.find("./pom:description", namespaces)

--- a/capycli/dependencies/maven_list.py
+++ b/capycli/dependencies/maven_list.py
@@ -166,7 +166,7 @@ class GetJavaMavenTreeDependencies(capycli.common.dependencies_base.Dependencies
                         # bomitem["SourceUrl"] = url
                         src_file_url = self.find_source_file(url, cx_comp.name, version)
                         CycloneDxSupport.update_or_set_ext_ref(
-                            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, src_file_url)
+                            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", src_file_url)
 
                         print(src_file_url)
             description = info.find("./pom:description", namespaces)

--- a/capycli/dependencies/maven_list.py
+++ b/capycli/dependencies/maven_list.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2020-2024 Siemens
+# Copyright (c) 2020-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com, manuel.schaffer@siemens.com
 #
@@ -65,8 +65,7 @@ class GetJavaMavenTreeDependencies(capycli.common.dependencies_base.Dependencies
 
         if src_url:
             ext_ref = ExternalReference(
-                type=ExternalReferenceType.DISTRIBUTION,
-                comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                 url=XsUri(src_url))
             cx_comp.external_references.add(ext_ref)
 
@@ -167,8 +166,7 @@ class GetJavaMavenTreeDependencies(capycli.common.dependencies_base.Dependencies
                         # bomitem["SourceUrl"] = url
                         src_file_url = self.find_source_file(url, cx_comp.name, version)
                         CycloneDxSupport.update_or_set_ext_ref(
-                            cx_comp, ExternalReferenceType.DISTRIBUTION,
-                            CaPyCliBom.SOURCE_URL_COMMENT, src_file_url)
+                            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", src_file_url)
 
                         print(src_file_url)
             description = info.find("./pom:description", namespaces)

--- a/capycli/dependencies/nuget.py
+++ b/capycli/dependencies/nuget.py
@@ -24,7 +24,7 @@ from packageurl import PackageURL
 import capycli.common.json_support
 import capycli.common.script_base
 from capycli import get_logger
-from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport, SbomCreator, SbomWriter
+from capycli.common.capycli_bom_support import CycloneDxSupport, SbomCreator, SbomWriter
 from capycli.common.print import print_red, print_text, print_yellow
 from capycli.main.result_codes import ResultCode
 
@@ -565,8 +565,7 @@ class GetNuGetDependencies(capycli.common.script_base.ScriptBase):
 
             if data.get("sourcecode", ""):
                 ext_ref = ExternalReference(
-                    type=ExternalReferenceType.DISTRIBUTION,
-                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                    type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                     url=XsUri(data["sourcecode"]))
                 cxcomp.external_references.add(ext_ref)
 
@@ -579,8 +578,7 @@ class GetNuGetDependencies(capycli.common.script_base.ScriptBase):
 
                 sourcecode = data["repository"] + "/archive/refs/tags/v" + cxcomp.version + ".zip"
                 ext_ref = ExternalReference(
-                    type=ExternalReferenceType.DISTRIBUTION,
-                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                    type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                     url=XsUri(sourcecode))
                 cxcomp.external_references.add(ext_ref)
                 LOG.debug("  got source file url")
@@ -601,8 +599,7 @@ class GetNuGetDependencies(capycli.common.script_base.ScriptBase):
                         data["project"] = data["project"][:-1]
                     sourcecode = data["project"] + "/archive/refs/tags/v" + cxcomp.version + ".zip"
                     ext_ref = ExternalReference(
-                        type=ExternalReferenceType.DISTRIBUTION,
-                        comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                        type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                         url=XsUri(sourcecode))
                     cxcomp.external_references.add(ext_ref)
                     LOG.debug("  got source file url")

--- a/capycli/dependencies/python.py
+++ b/capycli/dependencies/python.py
@@ -352,8 +352,7 @@ class GetPythonDependencies(capycli.common.script_base.ScriptBase):
                 source_url = fs.guess_source_code_url(homepage, version=version)
                 if source_url:
                     ext_ref = ExternalReference(
-                        type=ExternalReferenceType.DISTRIBUTION,
-                        comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                        type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                         url=XsUri(source_url))
                     cxcomp.external_references.add(ext_ref)
                     LOG.debug("  got GitHub source file url")
@@ -364,8 +363,7 @@ class GetPythonDependencies(capycli.common.script_base.ScriptBase):
                     source_url = fs.get_github_source_url(homepage, version=version)
                     if source_url:
                         ext_ref = ExternalReference(
-                            type=ExternalReferenceType.DISTRIBUTION,
-                            comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                            type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                             url=XsUri(source_url))
                         cxcomp.external_references.add(ext_ref)
                         LOG.debug("  got GitHub source file url")
@@ -419,8 +417,7 @@ class GetPythonDependencies(capycli.common.script_base.ScriptBase):
 
                             if not source_url:
                                 ext_ref = ExternalReference(
-                                    type=ExternalReferenceType.DISTRIBUTION,
-                                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                                    type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                                     url=XsUri(item["url"]),
                                     hashes=hashes)
                                 cxcomp.external_references.add(ext_ref)

--- a/capycli/dependencies/rust.py
+++ b/capycli/dependencies/rust.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2025 Siemens
+# Copyright (c) 2025-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -24,7 +24,7 @@ from packageurl import PackageURL
 import capycli.common.script_base
 from capycli import get_logger
 from capycli.bom.findsources import FindSources
-from capycli.common.capycli_bom_support import CaPyCliBom, CycloneDxSupport, SbomCreator, SbomWriter
+from capycli.common.capycli_bom_support import CycloneDxSupport, SbomCreator, SbomWriter
 from capycli.common.print import print_red, print_text, print_yellow
 from capycli.dependencies.python import GetPythonDependencies
 from capycli.main.result_codes import ResultCode
@@ -172,8 +172,7 @@ class GetRustDependencies(capycli.common.script_base.ScriptBase):
                 source_url = fs.guess_source_code_url(homepage, version=version)
                 if source_url:
                     ext_ref = ExternalReference(
-                        type=ExternalReferenceType.DISTRIBUTION,
-                        comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                        type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                         url=XsUri(source_url))
                     cxcomp.external_references.add(ext_ref)
                     LOG.debug("  got GitHub source file url")
@@ -184,8 +183,7 @@ class GetRustDependencies(capycli.common.script_base.ScriptBase):
                     source_url = fs.get_github_source_url(homepage, version=version)
                     if source_url:
                         ext_ref = ExternalReference(
-                            type=ExternalReferenceType.DISTRIBUTION,
-                            comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                            type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                             url=XsUri(source_url))
                         cxcomp.external_references.add(ext_ref)
                         LOG.debug("  got GitHub source file url")
@@ -195,8 +193,7 @@ class GetRustDependencies(capycli.common.script_base.ScriptBase):
             dl_path = "https://crates.io" + dl_path
             if not source_url and dl_path:
                 ext_ref = ExternalReference(
-                    type=ExternalReferenceType.DISTRIBUTION,
-                    comment=CaPyCliBom.SOURCE_URL_COMMENT,
+                    type=ExternalReferenceType.SOURCE_DISTRIBUTION,
                     url=XsUri(dl_path))
                 cxcomp.external_references.add(ext_ref)
                 LOG.debug("  got dl_path")

--- a/capycli/project/create_bom.py
+++ b/capycli/project/create_bom.py
@@ -1,5 +1,5 @@
 ﻿# -------------------------------------------------------------------------------
-# Copyright (c) 2021-2024 Siemens
+# Copyright (c) 2021-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com
 #
@@ -87,12 +87,15 @@ class CreateBom(capycli.common.script_base.ScriptBase):
                     languages = self.list_to_string(release_details["languages"])
                     CycloneDxSupport.set_property(rel_item, CycloneDxSupport.CDX_PROP_LANGUAGE, languages)
 
-                for key, comment in (("sourceCodeDownloadurl", CaPyCliBom.SOURCE_URL_COMMENT),
-                                     ("binaryDownloadurl", CaPyCliBom.BINARY_URL_COMMENT)):
-                    if key in release_details and release_details[key]:
-                        # add hash from attachment (see below) also here if same filename?
-                        CycloneDxSupport.set_ext_ref(rel_item, ExternalReferenceType.DISTRIBUTION,
-                                                     comment, release_details[key])
+                if "sourceCodeDownloadurl" in release_details and release_details["sourceCodeDownloadurl"]:
+                    # add hash from attachment (see below) also here if same filename?
+                    CycloneDxSupport.set_ext_ref(rel_item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+                                                 "", release_details["sourceCodeDownloadurl"])
+
+                if "binaryDownloadurl" in release_details and release_details["binaryDownloadurl"]:
+                    # add hash from attachment (see below) also here if same filename?
+                    CycloneDxSupport.set_ext_ref(rel_item, ExternalReferenceType.DISTRIBUTION,
+                                                 CaPyCliBom.BINARY_URL_COMMENT, release_details["binaryDownloadurl"])
 
                 if "repository" in release_details and "url" in release_details["repository"]:
                     CycloneDxSupport.set_ext_ref(rel_item, ExternalReferenceType.VCS, comment="",

--- a/tests/test_bom_create_releases.py
+++ b/tests/test_bom_create_releases.py
@@ -86,7 +86,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(cx_comp, CycloneDxSupport.CDX_PROP_SW360ID, "06a6e5")
         CycloneDxSupport.update_or_set_ext_ref(
-            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "new_url")
+            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
 
         items = Bom()
         items.components.add(cx_comp)
@@ -659,7 +659,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "Readme.md")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         # local filename with file:// prefix
@@ -675,7 +675,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(item, CycloneDxSupport.CDX_PROP_SRC_FILE_TYPE, "SOURCE_SELF")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         assert len(responses.calls) == 3
@@ -798,7 +798,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "__main__.py")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         # local filename guessed from remote url
@@ -807,7 +807,7 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         assert len(responses.calls) == 2
@@ -838,7 +838,7 @@ class TestBomCreate:
         # existing URL equals to new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "old_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "old_url")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" not in captured.out
@@ -846,7 +846,7 @@ class TestBomCreate:
         # existing URL differs from new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "https://some.new/file.tar.gz")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "https://some.new/file.tar.gz")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" in captured.out
@@ -867,7 +867,7 @@ class TestBomCreate:
         }
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "new_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
         self.app.update_release(item2, release_data)
         assert len(responses.calls) == 1
 

--- a/tests/test_bom_create_releases.py
+++ b/tests/test_bom_create_releases.py
@@ -86,7 +86,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(cx_comp, CycloneDxSupport.CDX_PROP_SW360ID, "06a6e5")
         CycloneDxSupport.update_or_set_ext_ref(
-            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
+            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "new_url")
 
         items = Bom()
         items.components.add(cx_comp)
@@ -659,7 +659,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "Readme.md")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         # local filename with file:// prefix
@@ -675,7 +675,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(item, CycloneDxSupport.CDX_PROP_SRC_FILE_TYPE, "SOURCE_SELF")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         assert len(responses.calls) == 3
@@ -798,7 +798,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "__main__.py")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         # local filename guessed from remote url
@@ -807,7 +807,7 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, None, my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         assert len(responses.calls) == 2
@@ -838,7 +838,7 @@ class TestBomCreate:
         # existing URL equals to new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "old_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "old_url")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" not in captured.out
@@ -846,7 +846,7 @@ class TestBomCreate:
         # existing URL differs from new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "https://some.new/file.tar.gz")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "https://some.new/file.tar.gz")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" in captured.out
@@ -867,7 +867,7 @@ class TestBomCreate:
         }
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "new_url")
         self.app.update_release(item2, release_data)
         assert len(responses.calls) == 1
 

--- a/tests/test_bom_create_releases.py
+++ b/tests/test_bom_create_releases.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2021-2025 Siemens
+# Copyright (c) 2021-2026 Siemens
 # All Rights Reserved.
 # Author: gernot.hillier@siemens.com, thomas.graf@siemens.com
 #
@@ -86,8 +86,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(cx_comp, CycloneDxSupport.CDX_PROP_SW360ID, "06a6e5")
         CycloneDxSupport.update_or_set_ext_ref(
-            cx_comp, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "new_url")
+            cx_comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
 
         items = Bom()
         items.components.add(cx_comp)
@@ -493,8 +492,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://rubygems.org/gems/activemodel-5.2.1.gem")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://rubygems.org/gems/activemodel-5.2.1.gem")
         release = self.app.create_release(item, "06a6e5")
         assert release is not None
         if release:
@@ -506,8 +505,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://rubygems.org/gems/activemodel-5.2.1.gem")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://rubygems.org/gems/activemodel-5.2.1.gem")
         CycloneDxSupport.update_or_set_property(item, CycloneDxSupport.CDX_PROP_COMPONENT_ID, "06a6e5")
         release = self.app.create_release(item, component_id="06a6e5")
         assert release is not None
@@ -541,8 +540,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "", "")
         CycloneDxSupport.update_or_set_ext_ref(
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "")
@@ -561,8 +560,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "", "")
         CycloneDxSupport.update_or_set_ext_ref(
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "notexist.txt")
@@ -594,8 +593,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://rubygems.org/gems/activemodel-5.2.1.gem")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://rubygems.org/gems/activemodel-5.2.1.gem")
         CycloneDxSupport.update_or_set_property(item, CycloneDxSupport.CDX_PROP_SRC_FILE_COMMENT, "testcomment")
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "testcomment")
 
@@ -633,8 +632,8 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://github.com/babel/babel/archive/refs/tags/v7.16.0.zip")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://github.com/babel/babel/archive/refs/tags/v7.16.0.zip")
         self.app.upload_file(item2, {}, "06a6e7", "SOURCE", "")
         captured = self.capsys.readouterr()  # type: ignore
         assert len(responses.calls) == 2
@@ -660,8 +659,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "Readme.md")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         # local filename with file:// prefix
@@ -677,8 +675,7 @@ class TestBomCreate:
         )
         CycloneDxSupport.update_or_set_property(item, CycloneDxSupport.CDX_PROP_SRC_FILE_TYPE, "SOURCE_SELF")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE_SELF", "")
 
         assert len(responses.calls) == 3
@@ -701,11 +698,11 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://github.com/babel/babel.git")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://github.com/babel/babel.git")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_FILE_COMMENT, "babel.git")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "babel.git")
 
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
         captured = self.capsys.readouterr()  # type: ignore
@@ -801,8 +798,7 @@ class TestBomCreate:
             item, ExternalReferenceType.DISTRIBUTION,
             CaPyCliBom.SOURCE_FILE_COMMENT, "__main__.py")
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         # local filename guessed from remote url
@@ -811,8 +807,7 @@ class TestBomCreate:
             version="5.2.1"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, my_url)
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION, "", my_url)
         self.app.upload_file(item, {}, "06a6e7", "SOURCE", "")
 
         assert len(responses.calls) == 2
@@ -843,8 +838,7 @@ class TestBomCreate:
         # existing URL equals to new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "old_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "old_url")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" not in captured.out
@@ -852,8 +846,7 @@ class TestBomCreate:
         # existing URL differs from new URL
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://some.new/file.tar.gz")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "https://some.new/file.tar.gz")
         self.app.update_release(item2, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "differs from BOM URL" in captured.out
@@ -874,8 +867,7 @@ class TestBomCreate:
         }
         item2 = Component(name="")
         CycloneDxSupport.update_or_set_ext_ref(
-            item2, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "new_url")
+            item2, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "new_url")
         self.app.update_release(item2, release_data)
         assert len(responses.calls) == 1
 
@@ -1173,8 +1165,8 @@ class TestBomCreate:
             version="7.16.0"
         )
         CycloneDxSupport.update_or_set_ext_ref(
-            item, ExternalReferenceType.DISTRIBUTION,
-            CaPyCliBom.SOURCE_URL_COMMENT, "https://github.com/babel/babel/archive/refs/tags/v7.16.0.zip")
+            item, ExternalReferenceType.SOURCE_DISTRIBUTION,
+            "new_url", "https://github.com/babel/babel/archive/refs/tags/v7.16.0.zip")
         self.app.update_release(item, release_data)
         captured = self.capsys.readouterr()  # type: ignore
         assert "different source attachment" in captured.out
@@ -1185,3 +1177,9 @@ class TestBomCreate:
         assert len(responses.calls) <= 1
         assert "Error" not in captured.out
         assert captured.err == ""
+
+
+if __name__ == '__main__':
+    APP = TestBomCreate()
+    APP.setUp()
+    APP.test_create_release_emptySourceFile()

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -3368,7 +3368,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "Java")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "888")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "http://456")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "http://456")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "456.zip")
         CycloneDxSupport.update_or_set_ext_ref(
@@ -3393,7 +3393,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "")
         CycloneDxSupport.update_or_set_ext_ref(

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -3368,7 +3368,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "Java")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "888")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "http://456")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "http://456")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "456.zip")
         CycloneDxSupport.update_or_set_ext_ref(
@@ -3393,7 +3393,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, None, "")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "")
         CycloneDxSupport.update_or_set_ext_ref(

--- a/tests/test_bom_map2.py
+++ b/tests/test_bom_map2.py
@@ -3368,7 +3368,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "Java")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "888")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_URL_COMMENT, "http://456")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "http://456")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "456.zip")
         CycloneDxSupport.update_or_set_ext_ref(
@@ -3393,7 +3393,7 @@ class CapycliTestBomMap(unittest.TestCase):
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_LANGUAGE, "")
         CycloneDxSupport.update_or_set_property(comp, CycloneDxSupport.CDX_PROP_SW360ID, "")
         CycloneDxSupport.update_or_set_ext_ref(
-            comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_URL_COMMENT, "")
+            comp, ExternalReferenceType.SOURCE_DISTRIBUTION, "", "")
         CycloneDxSupport.update_or_set_ext_ref(
             comp, ExternalReferenceType.DISTRIBUTION, CaPyCliBom.SOURCE_FILE_COMMENT, "")
         CycloneDxSupport.update_or_set_ext_ref(

--- a/tests/test_create_bom.py
+++ b/tests/test_create_bom.py
@@ -1,5 +1,5 @@
 # -------------------------------------------------------------------------------
-# Copyright (c) 2023 Siemens
+# Copyright (c) 2023-2026 Siemens
 # All Rights Reserved.
 # Author: thomas.graf@siemens.com, rayk.bajohr@siemens.com
 #
@@ -214,10 +214,11 @@ class TestCreateBom(TestBasePytest):
         cx_comp = cdx_bom.components[0]
         assert cx_comp.purl.to_string() == release["externalIds"]["package-url"]
 
-        ext_refs_src_url = [e for e in cx_comp.external_references if e.comment == CaPyCliBom.SOURCE_URL_COMMENT]
+        ext_refs_src_url = [e for e in cx_comp.external_references
+                            if e.type == ExternalReferenceType.SOURCE_DISTRIBUTION]
         assert len(ext_refs_src_url) == 1
         assert str(ext_refs_src_url[0].url) == release["sourceCodeDownloadurl"]
-        assert ext_refs_src_url[0].type == ExternalReferenceType.DISTRIBUTION
+        assert ext_refs_src_url[0].type == ExternalReferenceType.SOURCE_DISTRIBUTION
 
         ext_refs_src_file = [e for e in cx_comp.external_references if e.comment == CaPyCliBom.SOURCE_FILE_COMMENT]
         assert len(ext_refs_src_file) == 2
@@ -347,4 +348,4 @@ class TestCreateBom(TestBasePytest):
 
 if __name__ == "__main__":
     APP = TestCreateBom()
-    APP.test_project_show_by_name()
+    APP.test_project_by_id()


### PR DESCRIPTION
Update SBOM external reference type for source code URLs from `distribution`
  to `source-distribution`.