### PR TITLE
Improve usage of config files, and encourage it for Keycloak tokens

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@
 
 # CaPyCli - Clearing Automation Python Command Line Tool for SW360
 
+## NEXT
+
+* Config file can be located in home directory or current working directory.
+
 ## 2.12.0
 
 * Because of security reasons `-client_id` and `-client_secret` should only

--- a/capycli/main/options.py
+++ b/capycli/main/options.py
@@ -23,6 +23,17 @@ LOG = capycli.get_logger(__name__)
 
 class CommandlineSupport():
     CONFIG_FILE_NAME = ".capycli.cfg"
+    # Maps configuration file keys (derived from the long command line option
+    # name) to the internal name for options where the two differ.
+    CONFIG_KEY_ALIASES: Dict[str, str] = {
+        "url": "sw360_url",
+        "token": "sw360_token",
+        "raw-input": "raw_input",
+        "search-meta-data": "search_meta_data",
+        "old-version": "old_version",
+        "package-source": "package_source",
+        "forceexit": "force_exit",
+    }
 
     def __init__(self) -> None:
         custom_prog = capycli.get_app_signature()
@@ -511,27 +522,8 @@ class CommandlineSupport():
 
         if cfg:
             for key in cfg:
-                args_key = key
-
-                # handle some common naming mistakes
-                if args_key == "url":
-                    args_key = "sw360_url"
-                if args_key == "url":
-                    args_key = "sw360_url"
-                if args_key == "raw-input":
-                    args_key = "raw_input"
-                if args_key == "token":
-                    args_key = "sw360_token"
-                if args_key == "oa":
-                    args_key = "oauth2"
-                if args_key == "search-meta-data":
-                    args_key = "search_meta_data"
-                if args_key == "old-version":
-                    args_key = "old_version"
-                if args_key == "package-source":
-                    args_key = "package_source"
-                if args_key == "forceexit":
-                    args_key = "force_exit"
+                # replace command line options by internal arguments in case they differ
+                args_key = self.CONFIG_KEY_ALIASES.get(key, key)
 
                 if hasattr(args, args_key) and not args.__getattribute__(args_key):
                     args.__setattr__(args_key, cfg[key])

--- a/capycli/main/options.py
+++ b/capycli/main/options.py
@@ -33,6 +33,18 @@ class CommandlineSupport():
         "old-version": "old_version",
         "package-source": "package_source",
         "forceexit": "force_exit",
+        "overview": "create_overview",
+        "mapresult": "write_mapresult",
+        "rr": "result_required",
+        "if": "inputformat",
+        "of": "outputformat",
+        "remote-granularity": "remote_granularity_list",
+        "local-granularity": "local_granularity_list",
+        "remote-checklist": "remote_check_list",
+        "local-checklist": "local_checklist_list",
+        "X": "debug",
+        "forceerror": "force_error",
+        "project-mainline-state": "project_mainline_state",
     }
 
     def __init__(self) -> None:

--- a/capycli/main/options.py
+++ b/capycli/main/options.py
@@ -9,6 +9,7 @@
 """Contains the logic for all of the default options for CaPyCli."""
 
 import os
+import pathlib
 import tomllib
 from typing import Any, Dict
 
@@ -459,7 +460,18 @@ class CommandlineSupport():
 
     def read_config(self, filename: str = "", config_string: str = "") -> Dict[str, Any]:
         """
-        Read configuration from string or config file.
+        Read configuration from a TOML string or config file.
+
+        Lookup order (first source that is found wins, no merging):
+        1. config_string, if non-empty
+        2. filename, if non-empty
+        3. ./.capycli.cfg in the current working directory, if it exists
+        4. ~/.capycli.cfg, if it exists (%USERPROFILE%\\.capycli.cfg on Windows)
+
+        The TOML document must contain a [capycli] table; the keys of that
+        table are returned. Returns an empty dict if no source is found, if
+        the [capycli] table is missing, or on any parse or read error
+        (an error is logged in that case).
         """
 
         toml_dict = None
@@ -469,9 +481,13 @@ class CommandlineSupport():
             elif filename:
                 with open(filename, "rb") as f:
                     toml_dict = tomllib.load(f)
+            elif os.path.isfile(self.CONFIG_FILE_NAME):
+                with open(self.CONFIG_FILE_NAME, "rb") as f:
+                    toml_dict = tomllib.load(f)
             else:
-                if os.path.isfile(self.CONFIG_FILE_NAME):
-                    with open(self.CONFIG_FILE_NAME, "rb") as f:
+                home_config = pathlib.Path.home() / self.CONFIG_FILE_NAME
+                if os.path.isfile(home_config):
+                    with open(home_config, "rb") as f:
                         toml_dict = tomllib.load(f)
 
             if not toml_dict:


### PR DESCRIPTION
With the last release, handling of Keycloak client_id and client_secret was added which requires special care to avoid leaking these long-lived tokens. I think using the config file is the best solution here, so I tried to document this feature better and also added a corresponding warning if the user passes keycloak tokens on the commandline.