### PR TITLE
Fix #227: properly display SW360Error details on 4xx/5xx by checking response is not None

### DIFF
--- a/capycli/bom/check_bom.py
+++ b/capycli/bom/check_bom.py
@@ -66,7 +66,7 @@ class CheckBom(capycli.common.script_base.ScriptBase):
                     print(
                         "  " + component.name + ", " + version +
                         ", " + sw360id)
-                    if swex.response:
+                    if swex.response is not None:
                         print("  Status Code: " + str(swex.response.status_code))
                     if swex.message:
                         print("    Message: " + swex.message)
@@ -105,7 +105,7 @@ class CheckBom(capycli.common.script_base.ScriptBase):
                     print(Fore.LIGHTRED_EX + "  Error retrieving release data: ")
                     print(
                         "  " + component.name + ", " + version)
-                    if swex.response:
+                    if swex.response is not None:
                         print("  Status Code: " + str(swex.response.status_code))
                     if swex.message:
                         print("    Message: " + swex.message)

--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -146,7 +146,7 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             if swex.response.status_code == requests.codes["forbidden"]:
                 print_red("  You are not authorized - do you have a valid write token?")
                 sys.exit(ResultCode.RESULT_AUTH_ERROR)
-            if swex.response:
+            if swex.response is not None:
                 print_red("  " + str(swex.response.status_code) + ": " + swex.response.text)
                 sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)
             if swex.details:

--- a/capycli/project/create_project.py
+++ b/capycli/project/create_project.py
@@ -146,11 +146,11 @@ class CreateProject(capycli.common.script_base.ScriptBase):
             if swex.response.status_code == requests.codes["forbidden"]:
                 print_red("  You are not authorized - do you have a valid write token?")
                 sys.exit(ResultCode.RESULT_AUTH_ERROR)
-            if swex.response is not None:
-                print_red("  " + str(swex.response.status_code) + ": " + swex.response.text)
-                sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)
             if swex.details:
                 print_red("  " + swex.details.get("error", "") + ": " + swex.details.get("message", ""))
+                sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)
+            if swex.response.text:
+                print_red("  " + str(swex.response.status_code) + ": " + swex.response.text)
                 sys.exit(ResultCode.RESULT_ERROR_ACCESSING_SW360)
 
             print_red("  Unknown error updating project: " + repr(swex))


### PR DESCRIPTION
Fixes #227

### Description
This PR fixes an issue where SW360Error details were being silently swallowed for 4xx and 5xx HTTP responses.

The bug occurred because `requests.Response` implements `__bool__` such that it evaluates to `False` when `status_code >= 400`. Thus, `if swex.response:` was inadvertently skipping the error detail logging whenever a true HTTP error occurred, logging nothing instead. 

This has been resolved globally by explicitly checking `if swex.response is not None:`.
