### PR TITLE
Fix #218: properly parse stringified JSON array purls in RepositoryId

### DIFF
--- a/capycli/bom/map_bom.py
+++ b/capycli/bom/map_bom.py
@@ -507,9 +507,8 @@ class MapBom(capycli.common.script_base.ScriptBase):
         """
         raw_purl = ""
         if "RepositoryId" in match and match["RepositoryId"]:
-            return match["RepositoryId"]
-
-        if "ExternalIds" in match:
+            raw_purl = match["RepositoryId"]
+        elif "ExternalIds" in match:
             if "package-url" in match["ExternalIds"]:
                 raw_purl = match["ExternalIds"]["package-url"]
             elif "purl" in match["ExternalIds"]:
@@ -520,9 +519,9 @@ class MapBom(capycli.common.script_base.ScriptBase):
 
         purls = PurlUtils.parse_purls_from_external_id(raw_purl)
         if purls:
-            purl = purls[0]
+            return purls[0]
 
-        return purl
+        return ""
 
     def update_bom_item(self, component: Optional[Component], match: Dict[str, Any]) -> Component:
         """Update the (current) SBOM item with values from the match"""

--- a/tests/test_get_purl_from_match.py
+++ b/tests/test_get_purl_from_match.py
@@ -1,5 +1,5 @@
-import pytest
 from capycli.bom.map_bom import MapBom
+
 
 def test_get_purl_from_match_stringified_array():
     mb = MapBom()
@@ -7,6 +7,7 @@ def test_get_purl_from_match_stringified_array():
     match = {"RepositoryId": '["pkg:cargo/clap_builder@4.5.60","pkg:cargo/clap@4.5.60"]'}
     purl = mb.get_purl_from_match(match)
     assert purl == "pkg:cargo/clap_builder@4.5.60"
+
 
 def test_get_purl_from_match_single_purl():
     mb = MapBom()

--- a/tests/test_get_purl_from_match.py
+++ b/tests/test_get_purl_from_match.py
@@ -1,7 +1,7 @@
 from capycli.bom.map_bom import MapBom
 
 
-def test_get_purl_from_match_stringified_array():
+def test_get_purl_from_match_stringified_array() -> None:
     mb = MapBom()
     # Mocking match with a JSON array string
     match = {"RepositoryId": '["pkg:cargo/clap_builder@4.5.60","pkg:cargo/clap@4.5.60"]'}
@@ -9,7 +9,7 @@ def test_get_purl_from_match_stringified_array():
     assert purl == "pkg:cargo/clap_builder@4.5.60"
 
 
-def test_get_purl_from_match_single_purl():
+def test_get_purl_from_match_single_purl() -> None:
     mb = MapBom()
     match = {"RepositoryId": "pkg:cargo/clap@4.5.60"}
     purl = mb.get_purl_from_match(match)

--- a/tests/test_get_purl_from_match.py
+++ b/tests/test_get_purl_from_match.py
@@ -1,0 +1,15 @@
+import pytest
+from capycli.bom.map_bom import MapBom
+
+def test_get_purl_from_match_stringified_array():
+    mb = MapBom()
+    # Mocking match with a JSON array string
+    match = {"RepositoryId": '["pkg:cargo/clap_builder@4.5.60","pkg:cargo/clap@4.5.60"]'}
+    purl = mb.get_purl_from_match(match)
+    assert purl == "pkg:cargo/clap_builder@4.5.60"
+
+def test_get_purl_from_match_single_purl():
+    mb = MapBom()
+    match = {"RepositoryId": "pkg:cargo/clap@4.5.60"}
+    purl = mb.get_purl_from_match(match)
+    assert purl == "pkg:cargo/clap@4.5.60"


### PR DESCRIPTION
Fixes #218

### Description
This PR addresses issue #218 by correctly parsing stringified JSON arrays of purls in `RepositoryId` during BOM mapping.

Previously, `get_purl_from_match` was directly returning `match["RepositoryId"]` without passing it through `PurlUtils.parse_purls_from_external_id`. This caused an issue when SW360 mapping resulted in a single string that represented a JSON array of multiple purls (e.g. `'["pkg:cargo/clap_builder@4.5.60","pkg:cargo/clap@4.5.60"]'`), leading to a ValueError downstream in `PackageURL.from_string`.

By falling through to `parse_purls_from_external_id`, the stringified JSON array is safely decoded and the primary purl is extracted correctly.

Includes tests!
